### PR TITLE
Added option to specify custom llama model with prompt

### DIFF
--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -56,7 +56,7 @@ M.model = 'mistral:instruct'
 
 M.exec = function(options)
     local opts = vim.tbl_deep_extend('force', {
-        model = M.model,
+        model = options.model or M.model,
         command = M.command
     }, options)
     pcall(io.popen, 'ollama serve > /dev/null 2>&1 &')


### PR DESCRIPTION
This way coding prompts could use eg. codellama, 
grammar, summary - mistral
translate - could some other model. 
Example:

```lua
     prompts['Change_Code']= {
            prompt =
"Below is an instruction that describes a task. Write a response that appropriately completes the request.\n\n### Instruction:\n$input\n[CODE]\n$text\n[/CODE]\n".."\n\n### Response:",
            replace = false,
            extract = "```$filetype\n(.-)```",
            model = "mywizard_coder:latest",

      }
    end,    
```