### PR TITLE
Sort prompt keys for the prompt select menu

### DIFF
--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -142,6 +142,7 @@ M.prompts = prompts
 function select_prompt(cb)
     local promptKeys = {}
     for key, _ in pairs(M.prompts) do table.insert(promptKeys, key) end
+    table.sort(promptKeys)
     vim.ui.select(promptKeys, {
         prompt = 'Prompt:',
         format_item = function(item)


### PR DESCRIPTION
This will ensure that the select menu options have the same ordering every time the menu appears, since currently they are defined in a hash table and Lua provides no consistent ordering of items iterated via `pairs`. The default vim select menu utilizes numeric selection of options, so having consistent ordering is beneficial