### PR TITLE
Add $register variable for prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ You can use the following properties per prompt:
    - `$text`: Visually selected text
    - `$filetype`: Filetype of the buffer (e.g. `javascript`)
    - `$input`: Additional user input
+   - `$register`: Value of the unnamed register (yanked text)
 - `replace`: `true` if the selected text shall be replaced with the generated output
 - `extract`: Regular expression used to extract the generated result
 - `model`: The model to use, e.g. `zephyr`, default: `mistral:instruct`

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -182,6 +182,19 @@ vim.api.nvim_create_user_command('Gen', function(arg)
         M.exec(p)
     end)
 
-end, {range = true, nargs = '?'})
+end, {
+  range = true,
+  nargs = '?',
+  complete = function(ArgLead, CmdLine, CursorPos)
+    local promptKeys = {}
+    for key, _ in pairs(M.prompts) do
+      if key:lower():match("^"..ArgLead:lower()) then
+        table.insert(promptKeys, key)
+      end
+    end
+    table.sort(promptKeys)
+    return promptKeys
+  end
+})
 
 return M

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -86,6 +86,16 @@ M.exec = function(options)
             local answer = vim.fn.input("Prompt: ")
             text = string.gsub(text, "%$input", answer)
         end
+
+        if string.find(text, "%$register") then
+          local register = vim.fn.getreg('"')
+          if not register or register:match("^%s*$") then
+            error("Prompt uses $register but yank register is empty")
+          end
+
+          text = string.gsub(text, "%$register", register)
+        end
+
         text = string.gsub(text, "%$text", content)
         text = string.gsub(text, "%$filetype", vim.bo.filetype)
         return text


### PR DESCRIPTION
This will allow you to reference the value in the unnamed (yank) register in your prompts. I made it throw an error if that value is empty, not sure if this kind of error reported is desired in the project. Feel free to change the name of the variable as well.

The idea here is that you have three sources of input:
* The register with data to reference
* The visual selection with text to modify
* The prompt for instructions to perform

Here's an example of how it might be used with a custom prompt I made:

https://github.com/David-Kunz/gen.nvim/assets/15198/394448c5-a248-469c-91bc-2908005fd617


```lua
Modify_With_Reference = {
  prompt = table.concat({
    "Referencing the following:",
    "$register",
    "Modify the following text, $input, just output the final text without additional quotes around it:",
    "$text",
  }, "\n"),
  replace = true
}
```

