### PR TITLE
add complete function for :Gen command

### DIFF
--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -172,6 +172,19 @@ vim.api.nvim_create_user_command('Gen', function(arg)
         M.exec(p)
     end)
 
-end, {range = true, nargs = '?'})
+end, {
+  range = true,
+  nargs = '?',
+  complete = function(ArgLead, CmdLine, CursorPos)
+    local promptKeys = {}
+    for key, _ in pairs(M.prompts) do
+      if key:lower():match("^"..ArgLead:lower()) then
+        table.insert(promptKeys, key)
+      end
+    end
+    table.sort(promptKeys)
+    return promptKeys
+  end
+})
 
 return M


### PR DESCRIPTION
This adds a complete function to the `:Gen` user command with all the prompt names that match what's been typed (or listing everything if tab is pressed and nothing is typed.