### PR TITLE
Support defining a prompt as a function in addition to a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ require('gen').prompts['Fix_Code'] = {
 
 You can use the following properties per prompt:
 
-- `prompt`: Prompt which can use the following placeholders:
+- `prompt`: (string | function) Prompt either as a string or a function which should return a string. The result can use the following placeholders:
    - `$text`: Visually selected text
    - `$filetype`: Filetype of the buffer (e.g. `javascript`)
    - `$input`: Additional user input

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -129,7 +129,9 @@ M.exec = function(options)
             result_string = result_string .. table.concat(data, '\n')
             lines = vim.split(result_string, '\n', true)
             vim.api.nvim_buf_set_lines(result_buffer, 0, -1, false, lines)
-            vim.fn.feedkeys('$')
+            vim.api.nvim_win_call(float_win, function()
+              vim.fn.feedkeys('$')
+            end)
         end,
         on_exit = function(a, b)
             if b == 0 and opts.replace then

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -101,7 +101,16 @@ M.exec = function(options)
         return text
     end
 
-    local prompt = vim.fn.shellescape(substitute_placeholders(opts.prompt))
+    local prompt = opts.prompt
+
+    if type(prompt) == "function" then
+      prompt = prompt({
+        content = content,
+        filetype = vim.bo.filetype,
+      })
+    end
+
+    prompt = vim.fn.shellescape(substitute_placeholders(prompt))
     local extractor = substitute_placeholders(opts.extract)
     local cmd = opts.command
     cmd = string.gsub(cmd, "%$prompt", prompt)


### PR DESCRIPTION
This will allow you to provide a function when declaring the prompt for the `prompt` field. The function should return a string that will be used in the final prompt. The function is called every time a generate call is issued. Variables still work on the output string.

I gave the function one argument, a table of properties that are in scope relevant the interpolation of the prompt, should you want to do manual interpolation.

The purpose is to enable dynamic prompt generation that is more flexible than just the variable system. A few examples: 
* insert additional `vim.ui.input` calls to ask for more information about how to fill out the prompt
* automatically insert context on the prompt depending on the current file or directory.
* implement custom `$variables` in a prompt template string