### PR TITLE
fix: handle cancellation of vim.ui.select by user

### DIFF
--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -189,6 +189,7 @@ vim.api.nvim_create_user_command('Gen', function(arg)
         return M.exec(p)
     end
     select_prompt(function(item)
+        if not item then return end
         p = vim.tbl_deep_extend('force', {mode = mode}, M.prompts[item])
         M.exec(p)
     end)


### PR DESCRIPTION
Previously, closing the vim.ui.select window, e.g. with `<esc>` would cause this error:
```
Error executing vim.schedule lua callback: vim/shared.lua:0: after the second argument: expected table, got nil                                                                                                                                                 
stack traceback:                                                                                                                                                                                                                                                
        [C]: in function 'error'                                                                                                                                                                                                                                
        vim/shared.lua: in function 'validate'                                                                                                                                                                                                                  
        vim/shared.lua: in function 'tbl_deep_extend'                                                                                                                                                                                                           
        ...e/jonas/.local/share/nvim/lazy/gen.nvim/lua/gen/init.lua:192: in function 'cb'                                                                                                                                                                       
        ...e/jonas/.local/share/nvim/lazy/gen.nvim/lua/gen/init.lua:172: in function 'on_choice'                                                                                                                                                                
        ...are/nvim/lazy/dressing.nvim/lua/dressing/select/init.lua:78: in function ''                                                                                                                                                                          
        vim/_editor.lua: in function <vim/_editor.lua:0>     
```