### PR TITLE
feat: select model with ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Generate text using LLMs with customizable prompts
 ## Requires
 
 - [Ollama](https://ollama.ai/) with an appropriate model, e.g. [`mistral:instruct`](https://ollama.ai/library/mistral) or [`zephyr`](https://ollama.ai/library/zephyr) (customizable)
+- [plenary.nvim](https://github.com/nvim-lua/plenary.nvim)
 
 ## Usage
 
@@ -26,6 +27,12 @@ You can also directly invoke it with one of the [predefined prompts](./lua/gen/p
 
 ```lua
 vim.keymap.set('v', '<leader>]', ':Gen Enhance_Grammar_Spelling<CR>')
+```
+
+Use command `GenSelectModel` to get the list of all available models.
+
+```lua
+vim.keymap.set('n', '<leader>]', ':GenSelectModel<CR>')
 ```
 
 ## Options


### PR DESCRIPTION
Hi, I've been experimenting with ollama and found your awesome plugin.
Being able to tinker with ollama within neovim is super fun!

My idea was to make users able to select model on the fly without having to edit their config.
This PR aims to leverage ollama's REST API to make the most of its capabilities, and not just from its CLI tools.

This said, users can make use of the introduced `GenSelectModel` to set it on the fly (might be worth in the future to implement some sort of file caching for persistent settings).

I introduced `plenary.nvim` as dependency to this project (that might be worth if each and every plugin call will make use of the exposed REST API), specifically to use `plenary.curl` for HTTP requests.

I think this could be super useful for those who want to have a dedicated machine to host their ollama server and not having it locally.

Best regards
Francesco