### PR TITLE
feat: support for Docker container; printing command stderr to output window

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ You can use the following properties per prompt:
 - `replace`: `true` if the selected text shall be replaced with the generated output
 - `extract`: Regular expression used to extract the generated result
 - `model`: The model to use, e.g. `zephyr`, default: `mistral:instruct`
+- `container`: Specify name of ollama container if you are using Docker to host ollama service
+- `debugCommand`: Set to true redirects stderr of command execution to output window
 
 You can change the default model by setting `require('gen').model = 'your_model'`, e.g.
 
@@ -70,4 +72,12 @@ You can also change the complete command with
 require('gen').command = 'your command' -- default 'ollama run $model $prompt'
 ```
 
-You can use the placeholders `$model` and `$prompt`.
+You can use the placeholders `$model`, `$prompt` and `$container`.
+
+You can specify Docker container that hosts ollama
+
+```lua
+require('gen').container = 'container name' -- default nil
+```
+Default command will then change to
+`'docker exec $container ollama run $model $prompt'`

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -53,13 +53,26 @@ end
 
 M.command = 'ollama run $model $prompt'
 M.model = 'mistral:instruct'
+M.container = nil
+M.debugCommand = false
+
+local commandContainer = 'docker exec $container ollama run $model $prompt'
 
 M.exec = function(options)
+    if M.container ~= nil and M.command == 'ollama run $model $prompt' then
+        M.command = commandContainer
+    end
     local opts = vim.tbl_deep_extend('force', {
         model = M.model,
-        command = M.command
+        command = M.command,
+        container = M.container,
+        debugCommand = M.debugCommand
     }, options)
-    pcall(io.popen, 'ollama serve > /dev/null 2>&1 &')
+    if opts.container ~= nil then
+        pcall(io.popen, 'ollama serve > /dev/null 2>&1 &')
+    else
+        pcall(io.popen, 'docker start ' .. opts.container)
+    end
     curr_buffer = vim.fn.bufnr('%')
     local mode = opts.mode or vim.fn.mode()
     if mode == 'v' or mode == 'V' then
@@ -115,6 +128,9 @@ M.exec = function(options)
     local cmd = opts.command
     cmd = string.gsub(cmd, "%$prompt", prompt)
     cmd = string.gsub(cmd, "%$model", opts.model)
+    if opts.container ~= nil then
+        cmd = string.gsub(cmd, "%$container", opts.container)
+    end
     if result_buffer then vim.cmd('bd' .. result_buffer) end
     local win_opts = get_window_options()
     result_buffer = vim.api.nvim_create_buf(false, true)
@@ -139,6 +155,22 @@ M.exec = function(options)
               vim.fn.feedkeys('$')
             end)
         end,
+        on_stderr = function(_, data, _)
+            if opts.debugCommand then
+                -- window was closed, so cancel the job
+                if not vim.api.nvim_win_is_valid(float_win) then
+                    vim.fn.jobstop(job_id)
+                    return
+                end
+                result_string = result_string .. table.concat(data, '\n')
+                lines = vim.split(result_string, '\n', true)
+                vim.api.nvim_buf_set_lines(result_buffer, 0, -1, false, lines)
+                vim.api.nvim_win_call(float_win, function()
+                    vim.fn.feedkeys('$')
+                end)
+            end
+        end,
+        stderr_buffered = opts.debugCommand,
         on_exit = function(a, b)
             if b == 0 and opts.replace then
                 if extractor then


### PR DESCRIPTION
This plugin looks awesome, but unfortunately, due to tech stack at my job, I'm forced to use Windows for development, so I have to run ollama in Docker container.

I've decided to add Docker container support for users as one of default supported ways to use plugin. To achive that i allowed users to specify `container` option. It accepts name of docker container as string and if provided changes few plugin behaviours:

- plugin will use `docker start` instead of `ollama serve` to ensure that ollama service is available
- plugin will use `docker exec $container ollama run $model $prompt` as default execution command

During process i was struggling with command returning error output to stderr, that i couldn't see, so I also implemented additional boolean option debugCommand that if set to true, will print stderr of command to output window. I've decided to left it as part of this PR, as it may be usefull for future development and users having problems with not working custom command.

Best regards
Oskar