### PR TITLE
From mistral:instruct to mistral

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Example with Lazy
 {
     "David-Kunz/gen.nvim",
     opts = {
-        model = "mistral:instruct", -- The default model to use.
+        model = "mistral", -- The default model to use.
         display_mode = "float", -- The display mode. Can be "float" or "split".
         show_prompt = false, -- Shows the Prompt submitted to Ollama.
         show_model = false, -- Displays which model you are using at the beginning of your chat session.
@@ -44,7 +44,7 @@ Example with Lazy
         -- This can also be a lua function returning a command string, with options as the input parameter.
         -- The executed command must return a JSON object with { response, context }
         -- (context property is optional).
-        list_models = '<function>' -- Retrieves a list of model names
+        list_models = '<function>', -- Retrieves a list of model names
         debug = false -- Prints errors and the command which is run.
     }
 },

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -20,7 +20,7 @@ local function trim_table(tbl)
 end
 
 local default_options = {
-    model = "mistral:instruct",
+    model = "mistral",
     debug = false,
     show_prompt = false,
     show_model = false,


### PR DESCRIPTION
I changed the default model in `init.lua` and `README.md` from `mistral:instruct` to `mistral`
as `mistral:instruct` did not work and is also not in the [docs](https://ollama.ai/library/mistral)
(and fixed a missing comma in a code block in README.md).