### PR TITLE
substitute \"" with \\\" for cmd

### DIFF
--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -202,6 +202,7 @@ M.exec = function(options)
         if M.context then body.context = M.context end
         local json = vim.fn.json_encode(body)
         json = vim.fn.shellescape(json)
+        if vim.o.shell == 'cmd.exe' then json = string.gsub(json, '\\\"\"', '\\\\\\\"') end
         cmd = string.gsub(cmd, "%$body", json)
     end
 


### PR DESCRIPTION
This change fixes #4 for double quotes on windows.
On windows `vim.fn.shellescape()` by default assumes the resulting command is gonna be called with cmd, so it substitutes double quotes with a pair of double quotes (" -> ""), and `vim.fn.jobstart()` uses `vim.o.shell` to run commands which by default is `'cmd.exe'`.
The problem comes from `vim.fn.json_encode()` that already tries to espace double quotes as `\"` so after `vim.fn.shellescape()` there would be a `\""` for every `"` in the command body. 
This fix basically substitutes `\""` for `\\\"` so that the final command is valid and contains any double quotes in the prompt correctly escaped.

---
**Original code:** 
```lua
vim.opt.signcolumn = "yes"
```
**Windows before fix:**
```bash
curl --silent --no-buffer -X POST http://localhost:11434/api/generate -d "{""model"": ""zephyr"", ""stream"": true, ""prompt"": ""Summarize the following text:\nvim.opt.signcolumn = \""yes\""""}"
```
**Windows after fix:**
```bash
curl --silent --no-buffer -X POST http://localhost:11434/api/generate -d "{""model"": ""zephyr"", ""stream"": true, ""prompt"": ""Summarize the following text:\nvim.opt.signcolumn = \\\"yes\\\"""}"
```
**Linux:**
```bash
curl --silent --no-buffer -X POST http://localhost:11434/api/generate -d '{"model": "zephyr", "stream": true, "prompt": "Summarize the following text:\nvim.opt.signcolumn = \"yes\""}'
```