### PR TITLE
Fix typo in prompts.lua

### DIFF
--- a/lua/gen/prompts.lua
+++ b/lua/gen/prompts.lua
@@ -31,12 +31,12 @@ return {
         prompt = "Review the following code and make concise suggestions:\n```$filetype\n$text\n```",
     },
     Enhance_Code = {
-        prompt = "Enhance the following code, only ouput the result in format ```$filetype\n...\n```:\n```$filetype\n$text\n```",
+        prompt = "Enhance the following code, only output the result in format ```$filetype\n...\n```:\n```$filetype\n$text\n```",
         replace = true,
         extract = "```$filetype\n(.-)```",
     },
     Change_Code = {
-        prompt = "Regarding the following code, $input, only ouput the result in format ```$filetype\n...\n```:\n```$filetype\n$text\n```",
+        prompt = "Regarding the following code, $input, only output the result in format ```$filetype\n...\n```:\n```$filetype\n$text\n```",
         replace = true,
         extract = "```$filetype\n(.-)```",
     },


### PR DESCRIPTION
"output" was misspelled as "ouput" twice.