### PR TITLE
opt in to default prompts and streamline user prompts

### DIFF
--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -1,4 +1,6 @@
-local prompts = require("gen.prompts")
+
+local default_prompts = require("gen.prompts").load_default_prompts()
+local user_prompts = require("gen.prompts")
 local M = {}
 
 local curr_buffer = nil
@@ -28,7 +30,7 @@ local default_options = {
     json_response = true,
     no_auto_close = false,
     display_mode = "float",
-    no_auto_close = false,
+    load_default_prompts = true,
     init = function() pcall(io.popen, "ollama serve > /dev/null 2>&1 &") end,
     list_models = function()
         local response = vim.fn.systemlist(
@@ -343,10 +345,21 @@ end
 
 M.win_config = {}
 
-M.prompts = prompts
+
+
+M.prompts = function()
+    if M.load_default_prompts then
+        return default_prompts
+    else
+        return {}
+    end
+end
+
 function select_prompt(cb)
     local promptKeys = {}
-    for key, _ in pairs(M.prompts) do table.insert(promptKeys, key) end
+    if M.prompts ~= {} then
+        for key, _ in pairs(M.prompts()) do table.insert(promptKeys, key) end
+    end
     table.sort(promptKeys)
     vim.ui.select(promptKeys, {
         prompt = "Prompt:",

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -344,8 +344,8 @@ end
 
 M.win_config = {}
 
-M.prompts = function()
-    local user_prompts = prompts.user_prompts(M.user_prompts)
+function get_prompts()
+    local user_prompts = prompts.user_prompts(M.user_prompts) or {}
     if not M.load_default_prompts then
         return user_prompts
     end
@@ -357,10 +357,12 @@ M.prompts = function()
     return user_and_default_prompts
 end
 
+local all_prompts = get_prompts()
+
 function select_prompt(cb)
     local promptKeys = {}
     if M.prompts ~= {} then
-        for key, _ in pairs(M.prompts()) do table.insert(promptKeys, key) end
+        for key, _ in pairs(all_prompts) do table.insert(promptKeys, key) end
     end
     table.sort(promptKeys)
     vim.ui.select(promptKeys, {
@@ -379,7 +381,7 @@ vim.api.nvim_create_user_command("Gen", function(arg)
         mode = "v"
     end
     if arg.args ~= "" then
-        local prompt = M.prompts[arg.args]
+        local prompt = all_prompts[arg.args]
         if not prompt then
             print("Invalid prompt '" .. arg.args .. "'")
             return
@@ -389,7 +391,7 @@ vim.api.nvim_create_user_command("Gen", function(arg)
     end
     select_prompt(function(item)
         if not item then return end
-        p = vim.tbl_deep_extend("force", {mode = mode}, M.prompts[item])
+        p = vim.tbl_deep_extend("force", {mode = mode}, all_prompts[item])
         M.exec(p)
     end)
 end, {
@@ -397,7 +399,7 @@ end, {
     nargs = "?",
     complete = function(ArgLead, CmdLine, CursorPos)
         local promptKeys = {}
-        for key, _ in pairs(M.prompts) do
+        for key, _ in pairs(all_prompts) do
             if key:lower():match("^" .. ArgLead:lower()) then
                 table.insert(promptKeys, key)
             end

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -301,7 +301,6 @@ M.exec = function(options)
     })
 
     local group = vim.api.nvim_create_augroup("gen", {clear = true})
-    local event
     vim.api.nvim_create_autocmd('WinClosed', {
         buffer = M.result_buffer,
         group = group,

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -1,6 +1,5 @@
-
-local default_prompts = require("gen.prompts").load_default_prompts()
-local user_prompts = require("gen.prompts")
+local prompts = require("gen.prompts")
+local default_prompts = prompts.default_prompts()
 local M = {}
 
 local curr_buffer = nil
@@ -345,14 +344,17 @@ end
 
 M.win_config = {}
 
-
-
 M.prompts = function()
-    if M.load_default_prompts then
-        return default_prompts
-    else
-        return {}
+    local user_prompts = prompts.user_prompts(M.user_prompts)
+    if not M.load_default_prompts then
+        return user_prompts
     end
+
+    local user_and_default_prompts = user_prompts
+    for k, v in pairs(default_prompts) do
+        user_and_default_prompts[k] = v
+    end
+    return user_and_default_prompts
 end
 
 function select_prompt(cb)

--- a/lua/gen/prompts.lua
+++ b/lua/gen/prompts.lua
@@ -46,11 +46,5 @@ return {
 }
 end
 
--- this function is itself almost redundant, but it helps keep the
--- program syntax in init.lua clearer by accessing both user and default
--- prompts from the same file.
-M.user_prompts = function(prompts)
-    return prompts
-end
 
 return M

--- a/lua/gen/prompts.lua
+++ b/lua/gen/prompts.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-M.load_default_prompts = function()
+M.default_prompts = function()
 return {
     Generate = { prompt = "$input", replace = true },
     Chat = { prompt = "$input" },
@@ -46,5 +46,11 @@ return {
 }
 end
 
+-- this function is itself almost redundant, but it helps keep the
+-- program syntax in init.lua clearer by accessing both user and default
+-- prompts from the same file.
+M.user_prompts = function(prompts)
+    return prompts
+end
 
 return M

--- a/lua/gen/prompts.lua
+++ b/lua/gen/prompts.lua
@@ -1,3 +1,6 @@
+local M = {}
+
+M.load_default_prompts = function()
 return {
     Generate = { prompt = "$input", replace = true },
     Chat = { prompt = "$input" },
@@ -41,3 +44,7 @@ return {
         extract = "```$filetype\n(.-)```",
     },
 }
+end
+
+
+return M


### PR DESCRIPTION
Addresses David-Kunz#64.

This PR became more opinionated that intended... I hope it fits!

- Added a boolean option in setup() to include default prompts or not.
- Loading default prompts is now a function call. This gives space for using the
  prompts.lua file for other uses in the future (eg, other prompt functions or
  to load prompts based on filtering / specific models etc).
- Custom prompts can be added to the variable user_prompts instead of appended
  to the default prompts file directly

I'm however starting to pull some hair out... I don't know why the plugin isn't
respecting my settings for user_prompts and load_default_prompts. Setting
them in my config has no effect. Only their default settings within init.lua are
being respected...

Any pointers on that would be highly appreciated (with or without a PR
approval).

