### PR TITLE
feat: specify Ollama host and port in opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,19 @@ Example with Lazy
     "David-Kunz/gen.nvim",
     opts = {
         model = "mistral", -- The default model to use.
+        host = "localhost", -- The host running the Ollama service.
+        port = "11434", -- The port on which the Ollama service is listening.
         display_mode = "float", -- The display mode. Can be "float" or "split".
         show_prompt = false, -- Shows the Prompt submitted to Ollama.
         show_model = false, -- Displays which model you are using at the beginning of your chat session.
         no_auto_close = false, -- Never closes the window automatically.
         init = function(options) pcall(io.popen, "ollama serve > /dev/null 2>&1 &") end,
         -- Function to initialize Ollama
-        command = "curl --silent --no-buffer -X POST http://localhost:11434/api/generate -d $body",
+        command = function(options)
+            return "curl --silent --no-buffer -X POST http://" .. options.host .. ":" .. options.port .. "/api/generate -d $body"
+        end,
         -- The command for the Ollama service. You can use placeholders $prompt, $model and $body (shellescaped).
-        -- This can also be a lua function returning a command string, with options as the input parameter.
+        -- This can also be a command string.
         -- The executed command must return a JSON object with { response, context }
         -- (context property is optional).
         list_models = '<omitted lua function>', -- Retrieves a list of model names

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -21,18 +21,21 @@ end
 
 local default_options = {
     model = "mistral",
+    host = "localhost",
+    port = "11434",
     debug = false,
     show_prompt = false,
     show_model = false,
-    command = 'curl --silent --no-buffer -X POST http://localhost:11434/api/generate -d $body',
+    command = function(options)
+        return "curl --silent --no-buffer -X POST http://" .. options.host .. ":" .. options.port .. "/api/generate -d $body"
+    end,
     json_response = true,
-    no_auto_close = false,
     display_mode = "float",
     no_auto_close = false,
     init = function() pcall(io.popen, "ollama serve > /dev/null 2>&1 &") end,
-    list_models = function()
+    list_models = function(options)
         local response = vim.fn.systemlist(
-                             "curl --silent --no-buffer http://localhost:11434/api/tags")
+                             "curl --silent --no-buffer http://" .. options.host .. ":" .. options.port .. "/api/tags")
         local list = vim.fn.json_decode(response)
         local models = {}
         for key, _ in pairs(list.models) do
@@ -440,7 +443,7 @@ function process_response(str, job_id, json_response)
 end
 
 M.select_model = function()
-    local models = M.list_models()
+    local models = M.list_models(M)
     vim.ui.select(models, {prompt = "Model:"}, function(item, idx)
         if item ~= nil then
             print("Model set to " .. item)


### PR DESCRIPTION
Hi there,

First of all, thanks for the great plugin! I love its simplicity and functionality. I find it useful sometimes to run the ollama server on a different computer than the computer I'm developing locally on. With that in mind, I wonder if you'd be open to this PR that adds `host` and `port` to options, and updates the `command` and `list_models` functions to use the specified host and port. This makes it easier to select a different host/port without needing to replace `command` and `list_models` with custom functions.

This is my first time working on a neovim plugin, and I'm very open to feedback in terms of any changes that might be needed!

Thanks!