### PR TITLE
allow prompt function to cancel generate operation

### DIFF
--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -179,6 +179,9 @@ M.exec = function(options)
 
     if type(prompt) == "function" then
         prompt = prompt({content = content, filetype = vim.bo.filetype})
+        if type(prompt) ~= 'string' or string.len(prompt) == 0 then
+            return
+        end
     end
 
     prompt = substitute_placeholders(prompt)


### PR DESCRIPTION
This PR adds the ability to set a prompt function that returns an empty string or a nil value, with the intent to have `gen.nvim` skip this action.  It is expected that the prompt function will inform the user that the action was terminated.

For example the following custom prompt will only work if called with a selection, where `gen.nvim` will pass it the visual selection.  If the selection is empty, the prompt will print "content is empty!" and return `nil`.

```lua
        local gen = require'gen'
        gen.prompts['Testcases_for_code'] = {
            prompt = function(opt)
                if opt.content == "" then
                    print("content is empty!")
                    return nil
                end
                if opt.filetype == 'cpp' or opt.filetype == 'c' then
                    return "Using C++20 and googletest generate testcases for the following code:"
                        .. opt.content .. "\n"
                else
                    return "Using $filetype generate testcases for the following code:"
                        .. opt.content .. "\n"
                end
            end
        }
```