### PR TITLE
feat: support changes to nvim_buf_set_text()

### DIFF
--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -97,6 +97,10 @@ function write_to_buffer(lines)
     vim.api.nvim_buf_set_option(M.result_buffer, "modifiable", true)
     vim.api.nvim_buf_set_text(M.result_buffer, last_row - 1, last_col,
                               last_row - 1, last_col, vim.split(text, "\n"))
+    -- Move the cursor to the end of the new lines
+    local new_last_row = last_row + #lines - 1
+    vim.api.nvim_win_set_cursor(M.float_win, {new_last_row, 0})
+
     vim.api.nvim_buf_set_option(M.result_buffer, "modifiable", false)
 end
 


### PR DESCRIPTION
Hi David,

I'm still really enjoying working with your plugin!

I've noticed that on nightly versions of neovim (0.10-dev), there have been changes made to the nvim_buf_set_text() api. I believe the relevant PR that brought the changes in is [this one](https://github.com/neovim/neovim/pull/24901). As a result, when using gen.nvim in split mode, the buffer no longer scrolls as expected when ollama generates text that scrolls past the end of the viewable area. This PR adds support for proper buffer scrolling in nightly neovim versions (0.10-dev) while maintaining the functionality in the current stable versions of neovim. I believe that these changes to nvim_buf_set_text() will be in the next stable release of neovim.

Hopefully this will be useful, and if there are any changes you'd like me to make to the PR, I'd be glad to :)

Thanks,
John