### PR TITLE
fix: parse opts.prompt instead of prompt

### DIFF
--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -362,7 +362,7 @@ M.run_command = function(cmd, opts)
     })
 
     if opts.show_prompt then
-        local lines = vim.split(prompt, "\n")
+        local lines = vim.split(opts.prompt, "\n")
         local short_prompt = {}
         for i = 1, #lines do
             lines[i] = "> " .. lines[i]


### PR DESCRIPTION
Hi David,

I recently noticed a small issue when `opts.show_prompt` is set to true. An earlier commit (ed802f06a691895c8d6c5cf88b70b698a52514ad) introduced the `run_command` function. As a result of this function, the local variable `prompt` does not exist in the scope of the `run_command` function. Instead, when `opts.show_prompt` is true, we now parse the `opts.prompt` variable, which is available in the `run_command` function.

I believe this PR fixes the issue. Hopefully it's useful!

Thanks,
John