### PR TITLE
#107 feat: allow to refer named register with $register_<name>

### DIFF
--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -251,6 +251,14 @@ M.exec = function(options)
             text = string.gsub(text, "%$input", answer)
         end
 
+        text = string.gsub(text, "%$register_([%w*+:/\"])", function(r_name)
+            local register = vim.fn.getreg(r_name)
+            if not register or register:match("^%s*$") then
+                error("Prompt uses $register_" .. rname .. " but register " .. rname .. " is empty")
+            end
+            return register
+        end)
+
         if string.find(text, "%$register") then
             local register = vim.fn.getreg('"')
             if not register or register:match("^%s*$") then


### PR DESCRIPTION
#107 Allow to refer to named register with `$register_<name>`, for example:

- `$register_a` refer to content in named register `a`
- `$register_0` refer to content just yarned
- `$register_*` refer to content in system clipboard

This would help creating resilient AI assistant key maps without interrupting the main work flow or force overwriting the default register, for example
```
require('gen').prompts['ExplainTerm'] = {
  prompt = "Please translate \"$register_a\" into $register_l and explain its meaning in the follow text. Write your answer in $register_l:\n\n$register_b",
}

-- Explain the word under cursor or selection within the the context of the current sentence in a specific language
-- Language name should be stored in register L prior to performing the action, e.g. `let @l="English"`
vim.keymap.set({ 'n' }, ',dc', '"ayiw"byis:Gen ExplainTerm<CR>zR')
vim.keymap.set({ 'v' }, ',dc', '"ay"byis:Gen ExplainTerm<CR>zR')
```
