### PR TITLE
Add display mode for the prompt configuration

### DIFF
--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -178,7 +178,9 @@ local function create_window(cmd, opts)
         vim.api.nvim_set_option_value("linebreak", true,
                                       {win = globals.float_win})
     end
-    if M.display_mode == "float" then
+
+    local display_mode = opts.display_mode or M.display_mode
+    if display_mode == "float" then
         if globals.result_buffer then
             vim.api.nvim_buf_delete(globals.result_buffer, {force = true})
         end
@@ -190,7 +192,7 @@ local function create_window(cmd, opts)
 
         globals.float_win = vim.api.nvim_open_win(globals.result_buffer, true,
                                                   win_opts)
-    elseif M.display_mode == "horizontal-split" then
+    elseif display_mode == "horizontal-split" then
         vim.cmd("split gen.nvim")
         setup_split()
     else


### PR DESCRIPTION
Hi there!

On my use-case I need to specify what kind of `display_mode` I want on the `prompt`, instead of using a global from the `setup`. 

This MR makes the usage of a property of the same name (`display_mode`) from the prompt, and fallback on the default from the config in case of its missing property.

If you need me to change something else let me know,
Thanks in advance and thanks for the nice plugin! :D