### PR TITLE
fix: Disable curlrc

### DIFF
--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -48,7 +48,7 @@ local default_options = {
     retry_map = "<c-r>",
     hidden = false,
     command = function(options)
-        return "curl --silent --no-buffer -X POST http://" .. options.host ..
+        return "curl -q --silent --no-buffer -X POST http://" .. options.host ..
                    ":" .. options.port .. "/api/chat -d $body"
     end,
     json_response = true,
@@ -57,7 +57,7 @@ local default_options = {
     init = function() pcall(io.popen, "ollama serve > /dev/null 2>&1 &") end,
     list_models = function(options)
         local response = vim.fn.systemlist(
-                             "curl --silent --no-buffer http://" .. options.host ..
+                             "curl -q --silent --no-buffer http://" .. options.host ..
                                  ":" .. options.port .. "/api/tags")
         local list = vim.fn.json_decode(response)
         local models = {}


### PR DESCRIPTION
I have a [`curlrc` file](https://github.com/aldur/dotfiles/blob/master/various/curlrc) that enables more verbose logging.

`require('gen').select_model()` was failing because it tried parsing the additional output as well. 
This PR fixes the issue by ignoring the `rc`. I am not sure if it is the best approach, as someone might rely on the rc file e.g. to set proxies? If that's the case, we could make `curl` options an additional configuration parameter.

Here's the error log, just in case.

```log
|| E5108: Error executing lua Vim:E474: Unidentified byte: * Host localhost:11434 was resolved.
|| * IPv6: ::1
|| * IPv4: 127.0.0.1
|| *   Trying 127.0.0.1:11434...
|| * Connected to localhost (127.0.0.1) port 11434
|| > GET /api/tags HTTP/1.1
|| > Host: localhost:11434
|| > User-Agent: Mozilla/5.0 (Windows NT 6.1; rv:31.0) Gecko/20100101 Firefox/31.0
|| > Accept: */*
|| > 
|| * Request completely sent off
|| < HTTP/1.1 200 OK
|| < Content-Type: application/json; charset=utf-8
|| < Date: Fri, 18 Oct 2024 20:02:56 GMT
|| < Content-Length: 688
|| < 
|| { [688 bytes data]
|| {"models":[{"name":"nemotron:latest","model":"nemotron:latest","modified_at":"2024-10-18T10:13:14.558199923+02:00","size":42520412573,"digest":"2262f047a28a348ebbdb44fd275f68907aa8916cac6775456348a60f93add589","details":{"parent_model":"","format":"gguf","family":"llama","families":["llama"],"parameter_size":"70.6B","quantization_level":"Q4_K_M"}},{"name":"llama3.2:latest","model":"llama3.2:latest","modified_at":"2024-10-05T15:46:28.646864142+02:00","size":2019393189,"digest":"a80c4f17acd55265feec403c7aef86be0c2598
|| stack traceback:
|| 	[C]: in function 'json_decode'
|| 	/Users/aldur/Work/gen.nvim/lua/gen/init.lua:62: in function 'list_models'
|| 	/Users/aldur/Work/gen.nvim/lua/gen/init.lua:613: in function 'select_model'
|| 	[string ":lua"]:1: in main chunk
```