### PR TITLE
feat: Allow configuration of result filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Example with Lazy
         -- The executed command must return a JSON object with { response, context }
         -- (context property is optional).
         -- list_models = '<omitted lua function>', -- Retrieves a list of model names
-        debug = false -- Prints errors and the command which is run.
+        debug = false, -- Prints errors and the command which is run.
+        result_filetype = "markdown"  -- Configure filetype of the result buffer
     }
 },
 ```

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -66,7 +66,8 @@ local default_options = {
         end
         table.sort(models)
         return models
-    end
+    end,
+    result_filetype = "markdown"
 }
 for k, v in pairs(default_options) do M[k] = v end
 
@@ -178,7 +179,7 @@ local function create_window(cmd, opts)
     local function setup_split()
         globals.result_buffer = vim.fn.bufnr("%")
         globals.float_win = vim.fn.win_getid()
-        vim.api.nvim_set_option_value("filetype", "markdown",
+        vim.api.nvim_set_option_value("filetype", opts.result_filetype,
                                       {buf = globals.result_buffer})
         vim.api.nvim_set_option_value("buftype", "nofile",
                                       {buf = globals.result_buffer})
@@ -195,7 +196,7 @@ local function create_window(cmd, opts)
         local win_opts = vim.tbl_deep_extend("force", get_window_options(opts),
                                              opts.win_config)
         globals.result_buffer = vim.api.nvim_create_buf(false, true)
-        vim.api.nvim_set_option_value("filetype", "markdown",
+        vim.api.nvim_set_option_value("filetype", opts.result_filetype,
                                       {buf = globals.result_buffer})
 
         globals.float_win = vim.api.nvim_open_win(globals.result_buffer, true,


### PR DESCRIPTION
The default `markdown` filetype is great because it gives us syntax highlights etc. In my case though it also activates LSPs, some of which can be quite heavy (e.g., `ltex`) and were leading to full freezes. This options allows setting a new filetype for the result, giving more flexibility to users while having a sane default.

I personally use `markdown.gen` which gives me syntax highlights but does not trigger the LSPs.