### PR TITLE
feat: add multi-language support for chat prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,8 @@ Install with your favorite plugin manager, e.g. [lazy.nvim](https://github.com/f
 ```lua
 -- Minimal configuration
 { "Nonetss/gen-ollama.nvim" },
-```
 
-`````
+```
 
 ```lua
 -- Custom Parameters (with defaults)
@@ -127,7 +126,7 @@ require('gen').prompts['Fix_Code'] = {
   replace = true,
   extract = "```$filetype\n(.-)```"
 }
-`````
+````
 
 ### Prompt Properties
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is a **fork** of [David-Kunz/gen.nvim](https://github.com/David-Kunz/gen.nv
 
 - Added **multi-language support**, allowing you to set the language for prompts dynamically.
 - Refactored and modularized the codebase for improved maintainability and readability.
+- Introduced a new command, `:TGen`, which uses a special "thinking model" defined in the configuration.
 
 </div>
 
@@ -40,6 +41,7 @@ Install with your favorite plugin manager, e.g. [lazy.nvim](https://github.com/f
     "Nonetss/gen-ollama.nvim",
     opts = {
         model = "mistral", -- The default model to use.
+        thinking_model = "deepseek-r1", -- The "thinking model" used by the TGen command.
         language = "en", -- The default language for prompts (e.g., "en", "es").
         quit_map = "q", -- Set keymap to close the response window.
         retry_map = "<c-r>", -- Set keymap to re-send the current prompt.
@@ -80,7 +82,7 @@ require('gen').setup({
 
 Use the `Gen` command to generate text based on predefined and customizable prompts.
 
-Example keymaps:
+### Example keymaps
 
 ```lua
 vim.keymap.set({ 'n', 'v' }, '<leader>]', ':Gen<CR>')
@@ -101,6 +103,18 @@ After a conversation begins, the entire context is sent to the LLM. That allows 
 Once the window is closed, you start with a fresh conversation.
 
 For prompts that don't automatically replace the previously selected text (`replace = false`), you can replace the selected text with the generated output by pressing `<c-cr>`.
+
+### New Command: `:TGen`
+
+The `:TGen` command works similarly to `:Gen`, but uses the "thinking model" defined in the configuration (default: `deepseek-r1`). This command is ideal for tasks that require deeper analysis or specialized handling.
+
+Example keymaps:
+
+```lua
+vim.keymap.set({ 'n', 'v' }, '<leader>[', ':TGen<CR>')
+```
+
+### Selecting Models
 
 You can select a model from a list of all installed models with:
 
@@ -147,6 +161,7 @@ You can use the following properties per prompt:
 
 - **Multi-language prompts**: Add and switch between languages (e.g., English, Spanish).
 - **Refactored codebase**: The plugin's internals have been reorganized into smaller, more modular files for better maintainability.
+- **New command `:TGen`**: Use a specialized "thinking model" for deeper or more analytical tasks.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gen.nvim
+# gen-ollama.nvim
 
 Generate text using LLMs with customizable prompts
 
@@ -7,6 +7,15 @@ Generate text using LLMs with customizable prompts
 ![gen_nvim](https://github.com/David-Kunz/gen.nvim/assets/1009936/79f17157-9327-484a-811b-2d71ceb8fbe3)
 
 </div>
+
+## About this fork
+
+This is a **fork** of [David-Kunz/gen.nvim](https://github.com/David-Kunz/gen.nvim) with the following enhancements:
+
+- Added **multi-language support**, allowing you to set the language for prompts dynamically.
+- Refactored and modularized the codebase for improved maintainability and readability.
+
+---
 
 ## Video
 
@@ -23,48 +32,44 @@ Generate text using LLMs with customizable prompts
 
 ## Install
 
-Install with your favorite plugin manager, e.g. [lazy.nvim](https://github.com/folke/lazy.nvim)
+Install with your favorite plugin manager, e.g. [lazy.nvim](https://github.com/folke/lazy.nvim).
 
-Example with Lazy
+### Example with Lazy.nvim
 
 ```lua
 -- Minimal configuration
-{ "David-Kunz/gen.nvim" },
-
+{ "Nonetss/gen-ollama.nvim" },
 ```
 
-```lua
+`````
 
+```lua
 -- Custom Parameters (with defaults)
 {
-    "David-Kunz/gen.nvim",
+    "Nonetss/gen-ollama.nvim",
     opts = {
         model = "mistral", -- The default model to use.
-        quit_map = "q", -- set keymap to close the response window
-        retry_map = "<c-r>", -- set keymap to re-send the current prompt
-        accept_map = "<c-cr>", -- set keymap to replace the previous selection with the last result
+        language = "en", -- The default language for prompts (e.g., "en", "es").
+        quit_map = "q", -- Set keymap to close the response window.
+        retry_map = "<c-r>", -- Set keymap to re-send the current prompt.
+        accept_map = "<c-cr>", -- Set keymap to replace the previous selection with the last result.
         host = "localhost", -- The host running the Ollama service.
         port = "11434", -- The port on which the Ollama service is listening.
-        display_mode = "float", -- The display mode. Can be "float" or "split" or "horizontal-split".
+        display_mode = "float", -- The display mode. Can be "float", "split", or "horizontal-split".
         show_prompt = false, -- Shows the prompt submitted to Ollama. Can be true (3 lines) or "full".
         show_model = false, -- Displays which model you are using at the beginning of your chat session.
         no_auto_close = false, -- Never closes the window automatically.
         file = false, -- Write the payload to a temporary file to keep the command short.
-        hidden = false, -- Hide the generation window (if true, will implicitly set `prompt.replace = true`), requires Neovim >= 0.10
+        hidden = false, -- Hide the generation window (if true, will implicitly set `prompt.replace = true`), requires Neovim >= 0.10.
         init = function(options) pcall(io.popen, "ollama serve > /dev/null 2>&1 &") end,
-        -- Function to initialize Ollama
+        -- Function to initialize Ollama.
         command = function(options)
             local body = {model = options.model, stream = true}
             return "curl --silent --no-buffer -X POST http://" .. options.host .. ":" .. options.port .. "/api/chat -d $body"
         end,
-        -- The command for the Ollama service. You can use placeholders $prompt, $model and $body (shellescaped).
-        -- This can also be a command string.
-        -- The executed command must return a JSON object with { response, context }
-        -- (context property is optional).
-        -- list_models = '<omitted lua function>', -- Retrieves a list of model names
-        result_filetype = "markdown", -- Configure filetype of the result buffer
-        debug = false -- Prints errors and the command which is run.
-    }
+        result_filetype = "markdown", -- Configure filetype of the result buffer.
+        debug = false, -- Prints errors and the command which is run.
+    },
 },
 ```
 
@@ -74,17 +79,17 @@ Alternatively, you can call the `setup` function:
 
 ```lua
 require('gen').setup({
-  -- same as above
+  -- Same options as above.
 })
 ```
 
-
+---
 
 ## Usage
 
-Use command `Gen` to generate text based on predefined and customizable prompts.
+Use the `Gen` command to generate text based on predefined and customizable prompts.
 
-Example key maps:
+Example keymaps:
 
 ```lua
 vim.keymap.set({ 'n', 'v' }, '<leader>]', ':Gen<CR>')
@@ -96,28 +101,31 @@ You can also directly invoke it with one of the [predefined prompts](./lua/gen/p
 vim.keymap.set('v', '<leader>]', ':Gen Enhance_Grammar_Spelling<CR>')
 ```
 
-After a conversation begins, the entire context is sent to the LLM. That allows you to ask follow-up questions with
+After a conversation begins, the entire context is sent to the LLM. That allows you to ask follow-up questions with:
 
 ```lua
 :Gen Chat
 ```
 
-and once the window is closed, you start with a fresh conversation.
+Once the window is closed, you start with a fresh conversation.
 
-For prompts which don't automatically replace the previously selected text (`replace = false`), you can replace the selected text with the generated output with `<c-cr>`.
+For prompts that don't automatically replace the previously selected text (`replace = false`), you can replace the selected text with the generated output by pressing `<c-cr>`.
 
-You can select a model from a list of all installed models with
+You can select a model from a list of all installed models with:
 
 ```lua
 require('gen').select_model()
 ```
 
+---
+
 ## Custom Prompts
 
-[All prompts](./lua/gen/prompts.lua) are defined in `require('gen').prompts`, you can enhance or modify them.
+[All prompts](./lua/gen/prompts.lua) are defined in `require('gen').prompts`. You can enhance or modify them.
 
 Example:
-```lua
+
+````lua
 require('gen').prompts['Elaborate_Text'] = {
   prompt = "Elaborate the following text:\n$text",
   replace = true
@@ -127,18 +135,29 @@ require('gen').prompts['Fix_Code'] = {
   replace = true,
   extract = "```$filetype\n(.-)```"
 }
-```
+`````
+
+### Prompt Properties
 
 You can use the following properties per prompt:
 
-- `prompt`: (string | function) Prompt either as a string or a function which should return a string. The result can use the following placeholders:
-   - `$text`: Visually selected text or the content of the current buffer
-   - `$filetype`: File type of the buffer (e.g. `javascript`)
-   - `$input`: Additional user input
-   - `$register`: Value of the unnamed register (yanked text)
-- `replace`: `true` if the selected text shall be replaced with the generated output
-- `extract`: Regular expression used to extract the generated result
-- `model`: The model to use, default: `mistral`
+- **`prompt`**: (string | function) The prompt text, with placeholders:
+  - `$text`: Visually selected text or the content of the current buffer.
+  - `$filetype`: The file type of the buffer (e.g., `javascript`).
+  - `$input`: Additional user input.
+  - `$register`: Value of the unnamed register (yanked text).
+- **`replace`**: Whether the selected text should be replaced with the generated output (`true` by default).
+- **`extract`**: A regular expression to extract the generated result.
+- **`model`**: The model to use (default: `"mistral"`).
+
+---
+
+## Enhancements in this fork
+
+- **Multi-language prompts**: Add and switch between languages (e.g., English, Spanish).
+- **Refactored codebase**: The plugin's internals have been reorganized into smaller, more modular files for better maintainability.
+
+---
 
 ## Tip
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,6 @@ This is a **fork** of [David-Kunz/gen.nvim](https://github.com/David-Kunz/gen.nv
 - Added **multi-language support**, allowing you to set the language for prompts dynamically.
 - Refactored and modularized the codebase for improved maintainability and readability.
 
----
-
-## Video
-
-<div align="center">
-
-[![Local LLMs in Neovim: gen.nvim](https://user-images.githubusercontent.com/1009936/273126287-7b5f2b40-c678-47c5-8f21-edf9516f6034.jpg)](https://youtu.be/FIZt7MinpMY?si=KChSuJJDyrcTdYiM)
-
 </div>
 
 ## Requires

--- a/lua/gen/core/command.lua
+++ b/lua/gen/core/command.lua
@@ -1,0 +1,99 @@
+-- lua/gen/core/command.lua
+local globals = require("gen.utils.globals")
+local placeholders = require("gen.core.placeholders")
+
+local M = {}
+
+-- Genera el prompt final (sustituyendo placeholders),
+-- compone el JSON body y devuelve el comando resultante (cmd).
+function M.prepare_prompt_and_command(opts, content, globals)
+    -- 1) Resolvemos el prompt (si es tabla, usamos opts.language)
+    local prompt = opts.prompt
+    if type(prompt) == "table" then
+        prompt = prompt[opts.language]
+        if not prompt then
+            print("No prompt defined for language '" .. opts.language .. "'.")
+            return nil
+        end
+    end
+
+    -- 2) Si prompt es función, llamarla
+    if type(prompt) == "function" then
+        prompt = prompt({ content = content, filetype = vim.bo.filetype })
+    end
+
+    if not prompt or prompt == "" then
+        return nil
+    end
+
+    -- 3) Sustitución de placeholders
+    prompt = placeholders.substitute_placeholders(prompt, content)
+    opts.extract = placeholders.substitute_placeholders(opts.extract, content)
+
+    -- Reiniciamos la cadena de resultados
+    globals.result_string = ""
+
+    -- 4) Determinar comando final (string)
+    local cmd
+    if type(opts.command) == "function" then
+        cmd = opts.command(opts)
+    else
+        cmd = opts.command
+    end
+
+    -- Sustituimos $model si aparece en cmd
+    cmd = string.gsub(cmd, "%$model", opts.model)
+
+    -- Si aparece $prompt, lo escapamos
+    if string.find(cmd, "%$prompt") then
+        local escaped = vim.fn.shellescape(prompt)
+        cmd = string.gsub(cmd, "%$prompt", escaped)
+    end
+
+    -- 5) Si aparece $body, armamos el JSON
+    if string.find(cmd, "%$body") then
+        local body = vim.tbl_extend("force", { model = opts.model, stream = true }, opts.body or {})
+
+        -- Añadimos la conversación
+        local messages = globals.context or {}
+        table.insert(messages, { role = "user", content = prompt })
+        body.messages = messages
+
+        -- Combinar más opciones de modelo
+        if opts.model_options then
+            body = vim.tbl_extend("force", body, opts.model_options)
+        end
+
+        -- Función para json_encode
+        opts.json = opts.json
+            or function(obj, shellescape)
+                local encoded = vim.fn.json_encode(obj)
+                if shellescape then
+                    encoded = vim.fn.shellescape(encoded)
+                end
+                return encoded
+            end
+
+        -- Decidimos si guardar a un archivo temporal
+        if opts.file then
+            local json_str = opts.json(body, false)
+            globals.temp_filename = os.tmpname()
+            local f = io.open(globals.temp_filename, "w")
+            if f then
+                f:write(json_str)
+                f:close()
+            end
+            cmd = string.gsub(cmd, "%$body", "@" .. globals.temp_filename)
+        else
+            local json_str = opts.json(body, true)
+            cmd = string.gsub(cmd, "%$body", json_str)
+        end
+    end
+
+    -- Guardamos el prompt final
+    opts.prompt = prompt
+
+    return cmd, prompt
+end
+
+return M

--- a/lua/gen/core/placeholders.lua
+++ b/lua/gen/core/placeholders.lua
@@ -1,0 +1,47 @@
+-- lua/gen/core/placeholders.lua
+local M = {}
+
+-- Recibe un string 'text' con tokens ($input, $register, etc.)
+-- y 'content' que sustituye a $text.
+function M.substitute_placeholders(text, content)
+    if not text then
+        return text
+    end
+
+    -- 1) $input -> prompt que pide al usuario
+    if string.find(text, "%$input") then
+        local answer = vim.fn.input("Prompt: ")
+        text = string.gsub(text, "%$input", answer)
+    end
+
+    -- 2) $register_X
+    text = string.gsub(text, '%$register_([%w*+:/"])', function(r_name)
+        local regval = vim.fn.getreg(r_name)
+        if not regval or regval:match("^%s*$") then
+            error("Prompt uses $register_" .. r_name .. " but register is empty")
+        end
+        return regval
+    end)
+
+    -- 3) $register
+    if string.find(text, "%$register") then
+        local regval = vim.fn.getreg('"')
+        if not regval or regval:match("^%s*$") then
+            error("Prompt uses $register but yank register is empty")
+        end
+        text = string.gsub(text, "%$register", regval)
+    end
+
+    -- 4) Sustituir $text y $filetype
+    --    Ojo con los '%' en content
+    content = string.gsub(content, "%%", "%%%%")
+    text = string.gsub(text, "%$text", content)
+    text = string.gsub(text, "%$filetype", vim.bo.filetype)
+
+    -- 5) Finalmente escapar '%'
+    text = string.gsub(text, "%%", "%%%%")
+
+    return text
+end
+
+return M

--- a/lua/gen/core/prepare_options.lua
+++ b/lua/gen/core/prepare_options.lua
@@ -1,0 +1,16 @@
+-- lua/gen/core/prepare_options.lua
+local M = {}
+
+-- Combina opciones por defecto (base_config) con las del usuario (user_options).
+-- Aplica alguna lógica adicional si opts.hidden es true.
+function M.prepare_options(base_config, user_options)
+    local opts = vim.tbl_deep_extend("force", base_config, user_options or {})
+    if opts.hidden then
+        opts.display_mode = "float"
+        opts.replace = true
+    end
+    return opts
+end
+
+-- Exporta con un nombre más corto también
+return M.prepare_options

--- a/lua/gen/core/response.lua
+++ b/lua/gen/core/response.lua
@@ -1,0 +1,90 @@
+-- lua/gen/core/response.lua
+local globals = require("gen.utils.globals")
+local writer = require("gen.core.writer")
+
+local M = {}
+
+function M.process_response(str, json_response)
+    if #str == 0 then
+        return
+    end
+
+    local text
+    if json_response then
+        -- Caso: es JSON -> intentamos decodificar
+        -- Se quita el prefijo 'data: ' si aparece
+        if str:sub(1, 6) == "data: " then
+            str = str:gsub("data: ", "", 1)
+        end
+
+        local success, result = pcall(function()
+            return vim.fn.json_decode(str)
+        end)
+
+        if success then
+            -- Ollama chat endpoint
+            if result.message and result.message.content then
+                text = result.message.content
+                globals.context = globals.context or {}
+                globals.context_buffer = globals.context_buffer or ""
+                globals.context_buffer = globals.context_buffer .. text
+                if result.done then
+                    table.insert(globals.context, {
+                        role = "assistant",
+                        content = globals.context_buffer,
+                    })
+                    globals.context_buffer = ""
+                end
+
+            -- Groq chat endpoint
+            elseif result.choices then
+                local choice = result.choices[1]
+                text = choice.delta.content
+                if text then
+                    globals.context = globals.context or {}
+                    globals.context_buffer = globals.context_buffer or ""
+                    globals.context_buffer = globals.context_buffer .. text
+                end
+                if choice.finish_reason == "stop" then
+                    table.insert(globals.context, {
+                        role = "assistant",
+                        content = globals.context_buffer,
+                    })
+                    globals.context_buffer = ""
+                end
+
+            -- llamacpp version
+            elseif result.content then
+                text = result.content
+                globals.context = result.content
+
+            -- ollama generate endpoint
+            elseif result.response then
+                text = result.response
+                if result.context then
+                    globals.context = result.context
+                end
+            end
+        else
+            writer.write_to_buffer({ "", "====== ERROR ====", str, "-------------", "" }, globals)
+            if globals.job_id then
+                vim.fn.jobstop(globals.job_id)
+            end
+        end
+    else
+        text = str
+    end
+
+    if not text then
+        return
+    end
+
+    -- Añadimos el texto a la variable result_string
+    globals.result_string = globals.result_string .. text
+
+    -- Dividimos por líneas y escribimos al buffer
+    local lines = vim.split(text, "\n")
+    writer.write_to_buffer(lines, globals)
+end
+
+return M

--- a/lua/gen/core/selection.lua
+++ b/lua/gen/core/selection.lua
@@ -1,0 +1,53 @@
+-- lua/gen/core/selection.lua
+local M = {}
+
+-- Guarda en 'globals' el buffer y las posiciones de inicio/fin
+-- según modo visual (v/V) o cursor normal.
+function M.store_selection(opts, globals)
+    -- Solo si el buffer donde vamos a mostrar el resultado (result_buffer)
+    -- NO coincide con el buffer actual (winbufnr(0)).
+    if globals.result_buffer ~= vim.fn.winbufnr(0) then
+        globals.curr_buffer = vim.fn.winbufnr(0)
+        local mode = opts.mode or vim.fn.mode()
+
+        if mode == "v" or mode == "V" then
+            globals.start_pos = vim.fn.getpos("'<")
+            globals.end_pos = vim.fn.getpos("'>")
+            local max_col = vim.api.nvim_win_get_width(0)
+            if globals.end_pos[3] > max_col then
+                globals.end_pos[3] = vim.fn.col("'>") - 1
+            end
+        else
+            local cursor = vim.fn.getpos(".")
+            globals.start_pos = cursor
+            globals.end_pos = cursor
+        end
+    end
+end
+
+-- Devuelve el contenido (string) según la selección. Si no hay selección,
+-- devuelve el contenido entero del buffer actual.
+function M.get_content(globals)
+    if not globals.start_pos or not globals.end_pos then
+        return ""
+    end
+
+    if globals.start_pos[2] == globals.end_pos[2] and globals.start_pos[3] == globals.end_pos[3] then
+        -- Sin selección -> texto de todo el buffer
+        return table.concat(vim.api.nvim_buf_get_lines(globals.curr_buffer, 0, -1, false), "\n")
+    else
+        return table.concat(
+            vim.api.nvim_buf_get_text(
+                globals.curr_buffer,
+                globals.start_pos[2] - 1,
+                globals.start_pos[3] - 1,
+                globals.end_pos[2] - 1,
+                globals.end_pos[3],
+                {}
+            ),
+            "\n"
+        )
+    end
+end
+
+return M

--- a/lua/gen/core/writer.lua
+++ b/lua/gen/core/writer.lua
@@ -1,0 +1,44 @@
+-- lua/gen/core/writer.lua
+local M = {}
+
+function M.write_to_buffer(lines, globals)
+    if not globals.result_buffer or not vim.api.nvim_buf_is_valid(globals.result_buffer) then
+        return
+    end
+
+    -- Leemos las líneas actuales en el buffer
+    local all_lines = vim.api.nvim_buf_get_lines(globals.result_buffer, 0, -1, false)
+    local last_row = #all_lines
+    local last_row_content = all_lines[last_row] or ""
+    local last_col = #last_row_content
+
+    -- Unimos las líneas nuevas en un string
+    local text = table.concat(lines or {}, "\n")
+
+    -- Marcamos como modificable
+    vim.api.nvim_set_option_value("modifiable", true, { buf = globals.result_buffer })
+
+    -- Insertamos texto al final
+    vim.api.nvim_buf_set_text(
+        globals.result_buffer,
+        last_row - 1,
+        last_col,
+        last_row - 1,
+        last_col,
+        vim.split(text, "\n")
+    )
+
+    -- Ajustamos cursor
+    if globals.float_win and vim.api.nvim_win_is_valid(globals.float_win) then
+        local cursor_pos = vim.api.nvim_win_get_cursor(globals.float_win)
+        if cursor_pos[1] == last_row then
+            local new_last_row = last_row + #lines - 1
+            vim.api.nvim_win_set_cursor(globals.float_win, { new_last_row, 0 })
+        end
+    end
+
+    -- Volvemos a inmodificable
+    vim.api.nvim_set_option_value("modifiable", false, { buf = globals.result_buffer })
+end
+
+return M

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -5,7 +5,7 @@ local prompts = require("gen.prompts")
 local M = {}
 local default_options = require("gen.utils.default_options")
 
-local globals = {}
+local globals = require("gen.utils.globals")
 reset()
 
 for k, v in pairs(default_options) do

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -25,7 +25,9 @@ end
 reset()
 
 local function trim_table(tbl)
-    local function is_whitespace(str) return str:match("^%s*$") ~= nil end
+    local function is_whitespace(str)
+        return str:match("^%s*$") ~= nil
+    end
 
     while #tbl > 0 and (tbl[1] == "" or is_whitespace(tbl[1])) do
         table.remove(tbl, 1)
@@ -44,7 +46,8 @@ local default_options = {
     port = "11434",
     file = false,
     debug = false,
-    body = {stream = true},
+    language = "en",
+    body = { stream = true },
     show_prompt = false,
     show_model = false,
     quit_map = "q",
@@ -52,17 +55,22 @@ local default_options = {
     retry_map = "<c-r>",
     hidden = false,
     command = function(options)
-        return "curl -q --silent --no-buffer -X POST http://" .. options.host ..
-                   ":" .. options.port .. "/api/chat -d $body"
+        return "curl -q --silent --no-buffer -X POST http://"
+            .. options.host
+            .. ":"
+            .. options.port
+            .. "/api/chat -d $body"
     end,
     json_response = true,
     display_mode = "float",
     no_auto_close = false,
-    init = function() pcall(io.popen, "ollama serve > /dev/null 2>&1 &") end,
+    init = function()
+        pcall(io.popen, "ollama serve > /dev/null 2>&1 &")
+    end,
     list_models = function(options)
         local response = vim.fn.systemlist(
-                             "curl -q --silent --no-buffer http://" .. options.host ..
-                                 ":" .. options.port .. "/api/tags")
+            "curl -q --silent --no-buffer http://" .. options.host .. ":" .. options.port .. "/api/tags"
+        )
         local list = vim.fn.json_decode(response)
         local models = {}
         for key, _ in pairs(list.models) do
@@ -71,11 +79,17 @@ local default_options = {
         table.sort(models)
         return models
     end,
-    result_filetype = "markdown"
+    result_filetype = "markdown",
 }
-for k, v in pairs(default_options) do M[k] = v end
+for k, v in pairs(default_options) do
+    M[k] = v
+end
 
-M.setup = function(opts) for k, v in pairs(opts) do M[k] = v end end
+M.setup = function(opts)
+    for k, v in pairs(opts) do
+        M[k] = v
+    end
+end
 
 local function close_window(opts)
     local lines = {}
@@ -85,23 +99,25 @@ local function close_window(opts)
             if not opts.no_auto_close then
                 vim.api.nvim_win_hide(globals.float_win)
                 if globals.result_buffer ~= nil then
-                    vim.api.nvim_buf_delete(globals.result_buffer,
-                                            {force = true})
+                    vim.api.nvim_buf_delete(globals.result_buffer, { force = true })
                 end
                 reset()
             end
             return
         end
-        lines = vim.split(extracted, "\n", {trimempty = true})
+        lines = vim.split(extracted, "\n", { trimempty = true })
     else
-        lines = vim.split(globals.result_string, "\n", {trimempty = true})
+        lines = vim.split(globals.result_string, "\n", { trimempty = true })
     end
     lines = trim_table(lines)
-    vim.api.nvim_buf_set_text(globals.curr_buffer, globals.start_pos[2] - 1,
-                              globals.start_pos[3] - 1, globals.end_pos[2] - 1,
-                              globals.end_pos[3] > globals.start_pos[3] and
-                                  globals.end_pos[3] or globals.end_pos[3] - 1,
-                              lines)
+    vim.api.nvim_buf_set_text(
+        globals.curr_buffer,
+        globals.start_pos[2] - 1,
+        globals.start_pos[3] - 1,
+        globals.end_pos[2] - 1,
+        globals.end_pos[3] > globals.start_pos[3] and globals.end_pos[3] or globals.end_pos[3] - 1,
+        lines
+    )
     -- in case another replacement happens
     globals.end_pos[2] = globals.start_pos[2] + #lines - 1
     globals.end_pos[3] = string.len(lines[#lines])
@@ -110,7 +126,7 @@ local function close_window(opts)
             vim.api.nvim_win_hide(globals.float_win)
         end
         if globals.result_buffer ~= nil then
-            vim.api.nvim_buf_delete(globals.result_buffer, {force = true})
+            vim.api.nvim_buf_delete(globals.result_buffer, { force = true })
         end
         reset()
     end
@@ -138,7 +154,7 @@ local function get_window_options(opts)
         row = new_win_row,
         col = 0,
         style = "minimal",
-        border = "rounded"
+        border = "rounded",
     }
 
     local version = vim.version()
@@ -150,11 +166,11 @@ local function get_window_options(opts)
 end
 
 local function write_to_buffer(lines)
-    if not globals.result_buffer or
-        not vim.api.nvim_buf_is_valid(globals.result_buffer) then return end
+    if not globals.result_buffer or not vim.api.nvim_buf_is_valid(globals.result_buffer) then
+        return
+    end
 
-    local all_lines = vim.api.nvim_buf_get_lines(globals.result_buffer, 0, -1,
-                                                 false)
+    local all_lines = vim.api.nvim_buf_get_lines(globals.result_buffer, 0, -1, false)
 
     local last_row = #all_lines
     local last_row_content = all_lines[last_row]
@@ -162,10 +178,15 @@ local function write_to_buffer(lines)
 
     local text = table.concat(lines or {}, "\n")
 
-    vim.api.nvim_set_option_value("modifiable", true,
-                                  {buf = globals.result_buffer})
-    vim.api.nvim_buf_set_text(globals.result_buffer, last_row - 1, last_col,
-                              last_row - 1, last_col, vim.split(text, "\n"))
+    vim.api.nvim_set_option_value("modifiable", true, { buf = globals.result_buffer })
+    vim.api.nvim_buf_set_text(
+        globals.result_buffer,
+        last_row - 1,
+        last_col,
+        last_row - 1,
+        last_col,
+        vim.split(text, "\n")
+    )
 
     if globals.float_win ~= nil and vim.api.nvim_win_is_valid(globals.float_win) then
         local cursor_pos = vim.api.nvim_win_get_cursor(globals.float_win)
@@ -173,37 +194,31 @@ local function write_to_buffer(lines)
         -- Move the cursor to the end of the new lines
         if cursor_pos[1] == last_row then
             local new_last_row = last_row + #lines - 1
-            vim.api.nvim_win_set_cursor(globals.float_win, {new_last_row, 0})
+            vim.api.nvim_win_set_cursor(globals.float_win, { new_last_row, 0 })
         end
     end
 
-    vim.api.nvim_set_option_value("modifiable", false,
-                                  {buf = globals.result_buffer})
+    vim.api.nvim_set_option_value("modifiable", false, { buf = globals.result_buffer })
 end
 
 local function create_window(cmd, opts)
     local function setup_window()
         globals.result_buffer = vim.fn.bufnr("%")
         globals.float_win = vim.fn.win_getid()
-        vim.api.nvim_set_option_value("filetype", opts.result_filetype,
-                                      {buf = globals.result_buffer})
-        vim.api.nvim_set_option_value("buftype", "nofile",
-                                      {buf = globals.result_buffer})
-        vim.api.nvim_set_option_value("wrap", true, {win = globals.float_win})
-        vim.api.nvim_set_option_value("linebreak", true,
-                                      {win = globals.float_win})
+        vim.api.nvim_set_option_value("filetype", opts.result_filetype, { buf = globals.result_buffer })
+        vim.api.nvim_set_option_value("buftype", "nofile", { buf = globals.result_buffer })
+        vim.api.nvim_set_option_value("wrap", true, { win = globals.float_win })
+        vim.api.nvim_set_option_value("linebreak", true, { win = globals.float_win })
     end
 
     local display_mode = opts.display_mode or M.display_mode
     if display_mode == "float" then
         if globals.result_buffer then
-            vim.api.nvim_buf_delete(globals.result_buffer, {force = true})
+            vim.api.nvim_buf_delete(globals.result_buffer, { force = true })
         end
-        local win_opts = vim.tbl_deep_extend("force", get_window_options(opts),
-                                             opts.win_config)
+        local win_opts = vim.tbl_deep_extend("force", get_window_options(opts), opts.win_config)
         globals.result_buffer = vim.api.nvim_create_buf(false, true)
-        globals.float_win = vim.api.nvim_open_win(globals.result_buffer, true,
-                                                  win_opts)
+        globals.float_win = vim.api.nvim_open_win(globals.result_buffer, true, win_opts)
         setup_window()
     elseif display_mode == "horizontal-split" then
         vim.cmd("split gen.nvim")
@@ -213,14 +228,15 @@ local function create_window(cmd, opts)
         setup_window()
     end
     vim.keymap.set("n", "<esc>", function()
-        if globals.job_id then vim.fn.jobstop(globals.job_id) end
-    end, {buffer = globals.result_buffer})
-    vim.keymap.set("n", M.quit_map, "<cmd>quit<cr>",
-                   {buffer = globals.result_buffer})
+        if globals.job_id then
+            vim.fn.jobstop(globals.job_id)
+        end
+    end, { buffer = globals.result_buffer })
+    vim.keymap.set("n", M.quit_map, "<cmd>quit<cr>", { buffer = globals.result_buffer })
     vim.keymap.set("n", M.accept_map, function()
         opts.replace = true
         close_window(opts)
-    end, {buffer = globals.result_buffer})
+    end, { buffer = globals.result_buffer })
     vim.keymap.set("n", M.retry_map, function()
         local buf = 0 -- Current buffer
         if globals.job_id then
@@ -232,18 +248,20 @@ local function create_window(cmd, opts)
         vim.api.nvim_buf_set_option(buf, "modifiable", false)
         -- vim.api.nvim_win_close(0, true)
         M.run_command(cmd, opts)
-    end, {buffer = globals.result_buffer})
+    end, { buffer = globals.result_buffer })
 end
 
 M.exec = function(options)
     local opts = vim.tbl_deep_extend("force", M, options)
     if opts.hidden then
         -- the only reasonable thing to do if no output can be seen
-        opts.display_mode = 'float' -- uses the `hide` option
+        opts.display_mode = "float" -- uses the `hide` option
         opts.replace = true
     end
 
-    if type(opts.init) == 'function' then opts.init(opts) end
+    if type(opts.init) == "function" then
+        opts.init(opts)
+    end
 
     if globals.result_buffer ~= vim.fn.winbufnr(0) then
         globals.curr_buffer = vim.fn.winbufnr(0)
@@ -265,32 +283,34 @@ M.exec = function(options)
     local content
     if globals.start_pos == globals.end_pos then
         -- get text from whole buffer
-        content = table.concat(vim.api.nvim_buf_get_lines(globals.curr_buffer,
-                                                          0, -1, false), "\n")
+        content = table.concat(vim.api.nvim_buf_get_lines(globals.curr_buffer, 0, -1, false), "\n")
     else
-        content = table.concat(vim.api.nvim_buf_get_text(globals.curr_buffer,
-                                                         globals.start_pos[2] -
-                                                             1,
-                                                         globals.start_pos[3] -
-                                                             1,
-                                                         globals.end_pos[2] - 1,
-                                                         globals.end_pos[3], {}),
-                               "\n")
-
+        content = table.concat(
+            vim.api.nvim_buf_get_text(
+                globals.curr_buffer,
+                globals.start_pos[2] - 1,
+                globals.start_pos[3] - 1,
+                globals.end_pos[2] - 1,
+                globals.end_pos[3],
+                {}
+            ),
+            "\n"
+        )
     end
     local function substitute_placeholders(input)
-        if not input then return input end
+        if not input then
+            return input
+        end
         local text = input
         if string.find(text, "%$input") then
             local answer = vim.fn.input("Prompt: ")
             text = string.gsub(text, "%$input", answer)
         end
 
-        text = string.gsub(text, "%$register_([%w*+:/\"])", function(r_name)
+        text = string.gsub(text, '%$register_([%w*+:/"])', function(r_name)
             local register = vim.fn.getreg(r_name)
             if not register or register:match("^%s*$") then
-                error("Prompt uses $register_" .. rname .. " but register " ..
-                          rname .. " is empty")
+                error("Prompt uses $register_" .. rname .. " but register " .. rname .. " is empty")
             end
             return register
         end)
@@ -313,8 +333,8 @@ M.exec = function(options)
     local prompt = opts.prompt
 
     if type(prompt) == "function" then
-        prompt = prompt({content = content, filetype = vim.bo.filetype})
-        if type(prompt) ~= 'string' or string.len(prompt) == 0 then
+        prompt = prompt({ content = content, filetype = vim.bo.filetype })
+        if type(prompt) ~= "string" or string.len(prompt) == 0 then
             return
         end
     end
@@ -331,8 +351,8 @@ M.exec = function(options)
         local json = vim.fn.json_encode(body)
         if shellescape then
             json = vim.fn.shellescape(json)
-            if vim.o.shell == 'cmd.exe' then
-                json = string.gsub(json, '\\\"\"', '\\\\\\\"')
+            if vim.o.shell == "cmd.exe" then
+                json = string.gsub(json, '\\""', '\\\\\\"')
             end
         end
         return json
@@ -340,7 +360,7 @@ M.exec = function(options)
 
     opts.prompt = prompt
 
-    if type(opts.command) == 'function' then
+    if type(opts.command) == "function" then
         cmd = opts.command(opts)
     else
         cmd = M.command
@@ -352,13 +372,13 @@ M.exec = function(options)
     end
     cmd = string.gsub(cmd, "%$model", opts.model)
     if string.find(cmd, "%$body") then
-        local body = vim.tbl_extend("force",
-                                    {model = opts.model, stream = true},
-                                    opts.body)
+        local body = vim.tbl_extend("force", { model = opts.model, stream = true }, opts.body)
         local messages = {}
-        if globals.context then messages = globals.context end
+        if globals.context then
+            messages = globals.context
+        end
         -- Add new prompt to the context
-        table.insert(messages, {role = "user", content = prompt})
+        table.insert(messages, { role = "user", content = prompt })
         body.messages = messages
         if M.model_options ~= nil then -- llamacpp server - model options: eg. temperature, top_k, top_p
             body = vim.tbl_extend("force", body, M.model_options)
@@ -380,41 +400,43 @@ M.exec = function(options)
         end
     end
 
-    if globals.context ~= nil then write_to_buffer({"", "", "---", ""}) end
+    if globals.context ~= nil then
+        write_to_buffer({ "", "", "---", "" })
+    end
 
     M.run_command(cmd, opts)
-
 end
 
 M.run_command = function(cmd, opts)
     -- vim.print('run_command', cmd, opts)
-    if globals.result_buffer == nil or globals.float_win == nil or
-        not vim.api.nvim_win_is_valid(globals.float_win) then
+    if globals.result_buffer == nil or globals.float_win == nil or not vim.api.nvim_win_is_valid(globals.float_win) then
         create_window(cmd, opts)
         if opts.show_model then
-            write_to_buffer({"# Chat with " .. opts.model, ""})
+            write_to_buffer({ "# Chat with " .. opts.model, "" })
         end
     end
     local partial_data = ""
-    if opts.debug then print(cmd) end
+    if opts.debug then
+        print(cmd)
+    end
 
     globals.job_id = vim.fn.jobstart(cmd, {
         -- stderr_buffered = opts.debug,
         on_stdout = function(_, data, _)
             -- window was closed, so cancel the job
-            if not globals.float_win or
-                not vim.api.nvim_win_is_valid(globals.float_win) then
+            if not globals.float_win or not vim.api.nvim_win_is_valid(globals.float_win) then
                 if globals.job_id then
                     vim.fn.jobstop(globals.job_id)
                 end
                 if globals.result_buffer then
-                    vim.api.nvim_buf_delete(globals.result_buffer,
-                                            {force = true})
+                    vim.api.nvim_buf_delete(globals.result_buffer, { force = true })
                 end
                 reset()
                 return
             end
-            if opts.debug then vim.print('Response data: ', data) end
+            if opts.debug then
+                vim.print("Response data: ", data)
+            end
             for _, line in ipairs(data) do
                 partial_data = partial_data .. line
                 if line:sub(-1) == "}" then
@@ -422,7 +444,7 @@ M.run_command = function(cmd, opts)
                 end
             end
 
-            local lines = vim.split(partial_data, "\n", {trimempty = true})
+            local lines = vim.split(partial_data, "\n", { trimempty = true })
 
             partial_data = table.remove(lines) or ""
 
@@ -431,26 +453,25 @@ M.run_command = function(cmd, opts)
             end
 
             if partial_data:sub(-1) == "}" then
-                Process_response(partial_data, globals.job_id,
-                                 opts.json_response)
+                Process_response(partial_data, globals.job_id, opts.json_response)
                 partial_data = ""
             end
         end,
         on_stderr = function(_, data, _)
             if opts.debug then
                 -- window was closed, so cancel the job
-                if not globals.float_win or
-                    not vim.api.nvim_win_is_valid(globals.float_win) then
+                if not globals.float_win or not vim.api.nvim_win_is_valid(globals.float_win) then
                     if globals.job_id then
                         vim.fn.jobstop(globals.job_id)
                     end
                     return
                 end
 
-                if data == nil or #data == 0 then return end
+                if data == nil or #data == 0 then
+                    return
+                end
 
-                globals.result_string = globals.result_string ..
-                                            table.concat(data, "\n")
+                globals.result_string = globals.result_string .. table.concat(data, "\n")
                 local lines = vim.split(globals.result_string, "\n")
                 write_to_buffer(lines)
             end
@@ -459,20 +480,22 @@ M.run_command = function(cmd, opts)
             if b == 0 and opts.replace and globals.result_buffer then
                 close_window(opts)
             end
-        end
+        end,
     })
 
-    local group = vim.api.nvim_create_augroup("gen", {clear = true})
-    vim.api.nvim_create_autocmd('WinClosed', {
+    local group = vim.api.nvim_create_augroup("gen", { clear = true })
+    vim.api.nvim_create_autocmd("WinClosed", {
         buffer = globals.result_buffer,
         group = group,
         callback = function()
-            if globals.job_id then vim.fn.jobstop(globals.job_id) end
+            if globals.job_id then
+                vim.fn.jobstop(globals.job_id)
+            end
             if globals.result_buffer then
-                vim.api.nvim_buf_delete(globals.result_buffer, {force = true})
+                vim.api.nvim_buf_delete(globals.result_buffer, { force = true })
             end
             reset(true) -- keep selection in case of subsequent retries
-        end
+        end,
     })
 
     if opts.show_prompt then
@@ -489,15 +512,23 @@ M.run_command = function(cmd, opts)
             end
         end
         local heading = "#"
-        if M.show_model then heading = "##" end
+        if M.show_model then
+            heading = "##"
+        end
         write_to_buffer({
-            heading .. " Prompt:", "", table.concat(short_prompt, "\n"), "",
-            "---", ""
+            heading .. " Prompt:",
+            "",
+            table.concat(short_prompt, "\n"),
+            "",
+            "---",
+            "",
         })
     end
 
     vim.api.nvim_buf_attach(globals.result_buffer, false, {
-        on_detach = function() globals.result_buffer = nil end
+        on_detach = function()
+            globals.result_buffer = nil
+        end,
     })
 end
 
@@ -506,14 +537,23 @@ M.win_config = {}
 M.prompts = prompts
 local function select_prompt(cb)
     local promptKeys = {}
-    for key, _ in pairs(M.prompts) do table.insert(promptKeys, key) end
+    for key, _ in pairs(M.prompts) do
+        table.insert(promptKeys, key)
+    end
     table.sort(promptKeys)
+
     vim.ui.select(promptKeys, {
-        prompt = "Prompt:",
+        prompt = "Selecciona un Prompt:",
         format_item = function(item)
             return table.concat(vim.split(item, "_"), " ")
+        end,
+    }, function(selected_prompt)
+        if not selected_prompt then
+            cb(nil)
+            return
         end
-    }, function(item) cb(item) end)
+        cb(selected_prompt)
+    end)
 end
 
 vim.api.nvim_create_user_command("Gen", function(arg)
@@ -523,18 +563,55 @@ vim.api.nvim_create_user_command("Gen", function(arg)
     else
         mode = "v"
     end
+
     if arg.args ~= "" then
         local prompt = M.prompts[arg.args]
         if not prompt then
             print("Invalid prompt '" .. arg.args .. "'")
             return
         end
-        local p = vim.tbl_deep_extend("force", {mode = mode}, prompt)
+
+        -- Extract the prompt text based on the configured language
+        local prompt_text
+        if type(prompt.prompt) == "table" then
+            prompt_text = prompt.prompt[M.language]
+            if not prompt_text then
+                print("No prompt defined for language '" .. M.language .. "' in '" .. arg.args .. "'.")
+                return
+            end
+        else
+            prompt_text = prompt.prompt
+        end
+
+        -- Combine options and assign the extracted prompt
+        local p = vim.tbl_deep_extend("force", { mode = mode, prompt = prompt_text }, prompt)
         return M.exec(p)
     end
+
     select_prompt(function(item)
-        if not item then return end
-        local p = vim.tbl_deep_extend("force", {mode = mode}, M.prompts[item])
+        if not item then
+            return
+        end
+        local prompt = M.prompts[item]
+        if not prompt then
+            print("Prompt '" .. item .. "' not found.")
+            return
+        end
+
+        -- Extract the prompt text based on the configured language
+        local prompt_text
+        if type(prompt.prompt) == "table" then
+            prompt_text = prompt.prompt[M.language]
+            if not prompt_text then
+                print("No prompt defined for language '" .. M.language .. "' in '" .. item .. "'.")
+                return
+            end
+        else
+            prompt_text = prompt.prompt
+        end
+
+        -- Combine options and assign the extracted prompt
+        local p = vim.tbl_deep_extend("force", { mode = mode, prompt = prompt_text }, prompt)
         M.exec(p)
     end)
 end, {
@@ -549,11 +626,13 @@ end, {
         end
         table.sort(promptKeys)
         return promptKeys
-    end
+    end,
 })
 
 function Process_response(str, json_response)
-    if string.len(str) == 0 then return end
+    if string.len(str) == 0 then
+        return
+    end
     local text
 
     if json_response then
@@ -578,7 +657,7 @@ function Process_response(str, json_response)
                 if result.done then
                     table.insert(globals.context, {
                         role = "assistant",
-                        content = globals.context_buffer
+                        content = globals.context_buffer,
                     })
                     -- Clear the buffer as we're done with this sequence of messages
                     globals.context_buffer = ""
@@ -598,7 +677,7 @@ function Process_response(str, json_response)
                 if choice.finish_reason == "stop" then
                     table.insert(globals.context, {
                         role = "assistant",
-                        content = globals.context_buffer
+                        content = globals.context_buffer,
                     })
                     -- Clear the buffer as we're done with this sequence of messages
                     globals.context_buffer = ""
@@ -615,14 +694,16 @@ function Process_response(str, json_response)
                 end
             end
         else
-            write_to_buffer({"", "====== ERROR ====", str, "-------------", ""})
+            write_to_buffer({ "", "====== ERROR ====", str, "-------------", "" })
             vim.fn.jobstop(globals.job_id)
         end
     else
         text = str
     end
 
-    if text == nil then return end
+    if text == nil then
+        return
+    end
 
     globals.result_string = globals.result_string .. text
     local lines = vim.split(text, "\n")
@@ -631,7 +712,7 @@ end
 
 M.select_model = function()
     local models = M.list_models(M)
-    vim.ui.select(models, {prompt = "Model:"}, function(item)
+    vim.ui.select(models, { prompt = "Model:" }, function(item)
         if item ~= nil then
             print("Model set to " .. item)
             M.model = item

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -299,7 +299,7 @@ vim.api.nvim_create_user_command("TGen", function(arg)
     local old_model = M.config.model
 
     -- Cambiamos a nuestro modelo "pensante"
-    M.config.model = "thinking_model"
+    M.config.model = M.config.thinking_model
 
     if arg.args ~= "" then
         -- Se pasa prompt como argumento

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -295,9 +295,6 @@ vim.api.nvim_create_user_command("TGen", function(arg)
     -- Al igual que Gen, detectamos si hay selección
     local mode = (arg.range == 0) and "n" or "v"
 
-    -- Guardar modelo actual temporalmente
-    local old_model = M.config.model
-
     -- Cambiamos a nuestro modelo "pensante"
     M.config.model = M.config.thinking_model
 
@@ -308,7 +305,7 @@ vim.api.nvim_create_user_command("TGen", function(arg)
         if not prompt_obj then
             print("Invalid prompt '" .. prompt_key .. "'")
             -- restauramos el modelo original
-            M.config.model = old_model
+            M.config.model = M.config.thinking_model
             return
         end
 
@@ -318,7 +315,7 @@ vim.api.nvim_create_user_command("TGen", function(arg)
             if not prompt_text then
                 print("No prompt for language '" .. M.config.language .. "' in '" .. prompt_key .. "'.")
                 -- restauramos el modelo original
-                M.config.model = old_model
+                M.config.model = M.config.thinking_model
                 return
             end
         else
@@ -342,14 +339,14 @@ vim.api.nvim_create_user_command("TGen", function(arg)
             end,
         }, function(selected_prompt)
             if not selected_prompt then
-                M.config.model = old_model
+                M.config.model = M.config.thinking_model
                 return
             end
 
             local prompt_obj = prompts[selected_prompt]
             if not prompt_obj then
                 print("Prompt '" .. selected_prompt .. "' not found.")
-                M.config.model = old_model
+                M.config.model = M.config.thinking_model
                 return
             end
 
@@ -358,7 +355,7 @@ vim.api.nvim_create_user_command("TGen", function(arg)
                 prompt_text = prompt_obj.prompt[M.config.language]
                 if not prompt_text then
                     print("No prompt for language '" .. M.config.language .. "' in '" .. selected_prompt .. "'.")
-                    M.config.model = old_model
+                    M.config.model = M.config.thinking_model
                     return
                 end
             else
@@ -369,9 +366,6 @@ vim.api.nvim_create_user_command("TGen", function(arg)
             M.exec(final_opts)
         end)
     end
-
-    -- Finalmente, restauramos el modelo original para no afectar a "Gen"
-    M.config.model = old_model
 end, {
     range = true,
     nargs = "?",

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -259,6 +259,14 @@ M.exec = function(options)
         opts.replace = true
     end
 
+    if type(opts.prompt) == "table" then
+        opts.prompt = opts.prompt[M.language]
+        if not opts.prompt then
+            print("No prompt defined for language '" .. M.language .. "'.")
+            return
+        end
+    end
+
     if type(opts.init) == "function" then
         opts.init(opts)
     end

--- a/lua/gen/prompts.lua
+++ b/lua/gen/prompts.lua
@@ -1,42 +1,90 @@
 return {
-    Generate = { prompt = "$input", replace = true },
-    Chat = { prompt = "$input" },
-    Summarize = { prompt = "Summarize the following text:\n$text" },
-    Ask = { prompt = "Regarding the following text, $input:\n$text" },
+    Generate = {
+        prompt = {
+            en = "$input",
+            es = "$input",
+        },
+        replace = true,
+    },
+    Chat = {
+        prompt = {
+            en = "$input",
+            es = "$input",
+        },
+    },
+    Summarize = {
+        prompt = {
+            en = "Summarize the following text:\n$text",
+            es = "Resume el siguiente texto:\n$text",
+        },
+    },
+    Ask = {
+        prompt = {
+            en = "Regarding the following text, $input:\n$text",
+            es = "Con respecto al siguiente texto, $input:\n$text",
+        },
+    },
     Change = {
-        prompt = "Change the following text, $input, just output the final text without additional quotes around it:\n$text",
+        prompt = {
+            en = "Change the following text, $input, just output the final text without additional quotes around it:\n$text",
+            es = "Cambia el siguiente texto, $input, solo muestra el texto final sin comillas adicionales alrededor:\n$text",
+        },
         replace = true,
     },
     Enhance_Grammar_Spelling = {
-        prompt = "Modify the following text to improve grammar and spelling, just output the final text without additional quotes around it:\n$text",
+        prompt = {
+            en = "Modify the following text to improve grammar and spelling, just output the final text without additional quotes around it:\n$text",
+            es = "Modifica el siguiente texto para mejorar la gramática y la ortografía, solo muestra el texto final sin comillas adicionales alrededor:\n$text",
+        },
         replace = true,
     },
     Enhance_Wording = {
-        prompt = "Modify the following text to use better wording, just output the final text without additional quotes around it:\n$text",
+        prompt = {
+            en = "Modify the following text to use better wording, just output the final text without additional quotes around it:\n$text",
+            es = "Modifica el siguiente texto para usar una mejor redacción, solo muestra el texto final sin comillas adicionales alrededor:\n$text",
+        },
         replace = true,
     },
     Make_Concise = {
-        prompt = "Modify the following text to make it as simple and concise as possible, just output the final text without additional quotes around it:\n$text",
+        prompt = {
+            en = "Modify the following text to make it as simple and concise as possible, just output the final text without additional quotes around it:\n$text",
+            es = "Modifica el siguiente texto para que sea lo más simple y conciso posible, solo muestra el texto final sin comillas adicionales alrededor:\n$text",
+        },
         replace = true,
     },
     Make_List = {
-        prompt = "Render the following text as a markdown list:\n$text",
+        prompt = {
+            en = "Render the following text as a markdown list:\n$text",
+            es = "Renderiza el siguiente texto como una lista en formato markdown:\n$text",
+        },
         replace = true,
     },
     Make_Table = {
-        prompt = "Render the following text as a markdown table:\n$text",
+        prompt = {
+            en = "Render the following text as a markdown table:\n$text",
+            es = "Renderiza el siguiente texto como una tabla en formato markdown:\n$text",
+        },
         replace = true,
     },
     Review_Code = {
-        prompt = "Review the following code and make concise suggestions:\n```$filetype\n$text\n```",
+        prompt = {
+            en = "Review the following code and make concise suggestions:\n```$filetype\n$text\n```",
+            es = "Revisa el siguiente código y haz sugerencias concisas:\n```$filetype\n$text\n```",
+        },
     },
     Enhance_Code = {
-        prompt = "Enhance the following code, only output the result in format ```$filetype\n...\n```:\n```$filetype\n$text\n```",
+        prompt = {
+            en = "Enhance the following code, only output the result in format ```$filetype\n...\n```:\n```$filetype\n$text\n```",
+            es = "Mejora el siguiente código, solo muestra el resultado en formato ```$filetype\n...\n```:\n```$filetype\n$text\n```",
+        },
         replace = true,
         extract = "```$filetype\n(.-)```",
     },
     Change_Code = {
-        prompt = "Regarding the following code, $input, only output the result in format ```$filetype\n...\n```:\n```$filetype\n$text\n```",
+        prompt = {
+            en = "Regarding the following code, $input, only output the result in format ```$filetype\n...\n```:\n```$filetype\n$text\n```",
+            es = "Con respecto al siguiente código, $input, solo muestra el resultado en formato ```$filetype\n...\n```:\n```$filetype\n$text\n```",
+        },
         replace = true,
         extract = "```$filetype\n(.-)```",
     },

--- a/lua/gen/prompts.lua
+++ b/lua/gen/prompts.lua
@@ -1,8 +1,12 @@
 return {
     Generate = {
         prompt = {
-            en = [[Generate the following code. If additional explanations are needed, include them as comments in the syntax of $filetype. Output only the code: $input]],
-            es = [[Genera el siguiente código. Si se necesitan explicaciones adicionales, inclúyelas como comentarios usando la sintaxis de $filetype. Muestra solo el código: $input]],
+            en = [[Generate the following code. Include all explanations as inline comments using $filetype syntax.
+Do not include any additional text or descriptions outside the code:
+$input]],
+            es = [[Genera el siguiente código. Incluye todas las explicaciones como comentarios dentro del código usando la sintaxis de $filetype.
+No incluyas texto ni descripciones adicionales fuera del código:
+$input]],
         },
         replace = true,
     },

--- a/lua/gen/prompts.lua
+++ b/lua/gen/prompts.lua
@@ -1,8 +1,8 @@
 return {
     Generate = {
         prompt = {
-            en = "$input",
-            es = "$input",
+            en = [[Generate the following code. If additional explanations are needed, include them as comments in the syntax of $filetype. Output only the code: $input]],
+            es = [[Genera el siguiente código. Si se necesitan explicaciones adicionales, inclúyelas como comentarios usando la sintaxis de $filetype. Muestra solo el código: $input]],
         },
         replace = true,
     },
@@ -26,66 +26,71 @@ return {
     },
     Change = {
         prompt = {
-            en = "Change the following text, $input, just output the final text without additional quotes around it:\n$text",
-            es = "Cambia el siguiente texto, $input, solo muestra el texto final sin comillas adicionales alrededor:\n$text",
+            en = "Change the following text, $input, just output the final text without additional quotes:\n$text",
+            es = "Cambia el siguiente texto, $input, solo muestra el texto final sin comillas adicionales:\n$text",
         },
         replace = true,
     },
     Enhance_Grammar_Spelling = {
         prompt = {
-            en = "Modify the following text to improve grammar and spelling, just output the final text without additional quotes around it:\n$text",
-            es = "Modifica el siguiente texto para mejorar la gramática y la ortografía, solo muestra el texto final sin comillas adicionales alrededor:\n$text",
+            en = "Improve grammar and spelling in the following text. Output only the final text, no quotes:\n$text",
+            es = "Mejora la gramática y la ortografía del siguiente texto. Muestra solo el texto final, sin comillas:\n$text",
         },
         replace = true,
     },
     Enhance_Wording = {
         prompt = {
-            en = "Modify the following text to use better wording, just output the final text without additional quotes around it:\n$text",
-            es = "Modifica el siguiente texto para usar una mejor redacción, solo muestra el texto final sin comillas adicionales alrededor:\n$text",
+            en = "Use better wording for the following text. Output only the final text, no quotes:\n$text",
+            es = "Mejora la redacción del siguiente texto. Muestra solo el texto final, sin comillas:\n$text",
         },
         replace = true,
     },
     Make_Concise = {
         prompt = {
-            en = "Modify the following text to make it as simple and concise as possible, just output the final text without additional quotes around it:\n$text",
-            es = "Modifica el siguiente texto para que sea lo más simple y conciso posible, solo muestra el texto final sin comillas adicionales alrededor:\n$text",
+            en = "Make the following text simple and concise. Output only the final text, no quotes:\n$text",
+            es = "Haz que el siguiente texto sea lo más simple y conciso posible. Muestra solo el texto final, sin comillas:\n$text",
         },
         replace = true,
     },
     Make_List = {
         prompt = {
-            en = "Render the following text as a markdown list:\n$text",
-            es = "Renderiza el siguiente texto como una lista en formato markdown:\n$text",
+            en = "Convert the following text into a list. Output only the list (no extra text):\n$text",
+            es = "Convierte el siguiente texto en una lista. Muestra solo la lista (sin texto extra):\n$text",
         },
         replace = true,
     },
     Make_Table = {
         prompt = {
-            en = "Render the following text as a markdown table:\n$text",
-            es = "Renderiza el siguiente texto como una tabla en formato markdown:\n$text",
+            en = "Convert the following text into a table (no markdown). Output only the table:\n$text",
+            es = "Convierte el siguiente texto en una tabla (sin markdown). Muestra solo la tabla:\n$text",
         },
         replace = true,
     },
+
+    -- ========================================
+    --   EJEMPLOS PARA PROMPTS DE CÓDIGO
+    -- ========================================
     Review_Code = {
         prompt = {
-            en = "Review the following code and make concise suggestions:\n```$filetype\n$text\n```",
-            es = "Revisa el siguiente código y haz sugerencias concisas:\n```$filetype\n$text\n```",
+            en = [[Review the following code and make concise suggestions. If you add explanations, put them as comments in the $filetype syntax. Output only the modified code with comments included: $text]],
+            es = [[Revisa el siguiente código y haz sugerencias concisas. Si añades explicaciones, ponlas como comentarios usando la sintaxis de $filetype. Muestra solo el código modificado con los comentarios incluidos: $text]],
         },
     },
+
     Enhance_Code = {
         prompt = {
-            en = "Enhance the following code, only output the result in format ```$filetype\n...\n```:\n```$filetype\n$text\n```",
-            es = "Mejora el siguiente código, solo muestra el resultado en formato ```$filetype\n...\n```:\n```$filetype\n$text\n```",
+            en = [[Enhance the following code. If you add explanations, include them as valid $filetype comments. Output only the final code, no markdown or extra quotes: $text]],
+            es = [[Mejora el siguiente código. Si añades explicaciones, inclúyelas como comentarios válidos de $filetype. Muestra solo el código final, sin markdown ni comillas extra: $text]],
         },
         replace = true,
-        extract = "```$filetype\n(.-)```",
+        -- Quita el extract si ya no usas ``` fences
+        -- extract = "```$filetype\n(.-)```",
     },
     Change_Code = {
         prompt = {
-            en = "Regarding the following code, $input, only output the result in format ```$filetype\n...\n```:\n```$filetype\n$text\n```",
-            es = "Con respecto al siguiente código, $input, solo muestra el resultado en formato ```$filetype\n...\n```:\n```$filetype\n$text\n```",
+            en = [[Make the following changes to the code, $input. If you need to explain, add inline comments in $filetype. Output only the resulting code, no markdown fences: $text]],
+            es = [[Realiza los siguientes cambios en el código, $input. Si necesitas explicar algo, añádelo como comentarios en $filetype.  Muestra únicamente el código resultante, sin formateo markdown: $text]],
         },
         replace = true,
-        extract = "```$filetype\n(.-)```",
     },
 }

--- a/lua/gen/utils/default_options.lua
+++ b/lua/gen/utils/default_options.lua
@@ -1,5 +1,6 @@
 local default_options = {
     model = "mistral",
+    thinking_model = "deepseek-r1",
     host = "localhost",
     port = "11434",
     file = false,

--- a/lua/gen/utils/default_options.lua
+++ b/lua/gen/utils/default_options.lua
@@ -1,0 +1,43 @@
+local default_options = {
+    model = "mistral",
+    host = "localhost",
+    port = "11434",
+    file = false,
+    debug = false,
+    language = "en",
+    body = { stream = true },
+    show_prompt = false,
+    show_model = false,
+    quit_map = "q",
+    accept_map = "<c-cr>",
+    retry_map = "<c-r>",
+    hidden = false,
+    command = function(options)
+        return "curl -q --silent --no-buffer -X POST http://"
+            .. options.host
+            .. ":"
+            .. options.port
+            .. "/api/chat -d $body"
+    end,
+    json_response = true,
+    display_mode = "float",
+    no_auto_close = false,
+    init = function()
+        pcall(io.popen, "ollama serve > /dev/null 2>&1 &")
+    end,
+    list_models = function(options)
+        local response = vim.fn.systemlist(
+            "curl -q --silent --no-buffer http://" .. options.host .. ":" .. options.port .. "/api/tags"
+        )
+        local list = vim.fn.json_decode(response)
+        local models = {}
+        for key, _ in pairs(list.models) do
+            table.insert(models, list.models[key].name)
+        end
+        table.sort(models)
+        return models
+    end,
+    result_filetype = "markdown",
+}
+
+return default_options

--- a/lua/gen/utils/globals.lua
+++ b/lua/gen/utils/globals.lua
@@ -1,0 +1,15 @@
+-- lua/gen/utils/globals.lua
+local M = {
+    job_id = nil,
+    result_buffer = nil,
+    float_win = nil,
+    result_string = "",
+    context = nil,
+    context_buffer = nil,
+    curr_buffer = nil,
+    start_pos = nil,
+    end_pos = nil,
+    temp_filename = nil,
+}
+
+return M

--- a/lua/gen/utils/reset.lua
+++ b/lua/gen/utils/reset.lua
@@ -1,4 +1,4 @@
-local globals = {}
+local globals = require("gen.utils.globals")
 
 local function reset(keep_selection)
     if not keep_selection then

--- a/lua/gen/utils/reset.lua
+++ b/lua/gen/utils/reset.lua
@@ -1,0 +1,24 @@
+local globals = {}
+
+local function reset(keep_selection)
+    if not keep_selection then
+        globals.curr_buffer = nil
+        globals.start_pos = nil
+        globals.end_pos = nil
+    end
+    if globals.job_id then
+        vim.fn.jobstop(globals.job_id)
+        globals.job_id = nil
+    end
+    globals.result_buffer = nil
+    globals.float_win = nil
+    globals.result_string = ""
+    globals.context = nil
+    globals.context_buffer = nil
+    if globals.temp_filename then
+        os.remove(globals.temp_filename)
+        globals.temp_filename = nil
+    end
+end
+
+return reset

--- a/lua/gen/utils/trim_table.lua
+++ b/lua/gen/utils/trim_table.lua
@@ -1,0 +1,17 @@
+local function trim_table(tbl)
+    local function is_whitespace(str)
+        return str:match("^%s*$") ~= nil
+    end
+
+    while #tbl > 0 and (tbl[1] == "" or is_whitespace(tbl[1])) do
+        table.remove(tbl, 1)
+    end
+
+    while #tbl > 0 and (tbl[#tbl] == "" or is_whitespace(tbl[#tbl])) do
+        table.remove(tbl, #tbl)
+    end
+
+    return tbl
+end
+
+return trim_table

--- a/lua/gen/window/close.lua
+++ b/lua/gen/window/close.lua
@@ -1,6 +1,6 @@
 local reset = require("gen.utils.reset")
 local trim_table = require("gen.utils.trim_table")
-local globals = {}
+local globals = require("gen.utils.globals")
 
 local function close_window(opts)
     local lines = {}

--- a/lua/gen/window/close.lua
+++ b/lua/gen/window/close.lua
@@ -1,0 +1,46 @@
+local reset = require("gen.utils.reset")
+local trim_table = require("gen.utils.trim_table")
+local globals = {}
+
+local function close_window(opts)
+    local lines = {}
+    if opts.extract then
+        local extracted = globals.result_string:match(opts.extract)
+        if not extracted then
+            if not opts.no_auto_close then
+                vim.api.nvim_win_hide(globals.float_win)
+                if globals.result_buffer ~= nil then
+                    vim.api.nvim_buf_delete(globals.result_buffer, { force = true })
+                end
+                reset()
+            end
+            return
+        end
+        lines = vim.split(extracted, "\n", { trimempty = true })
+    else
+        lines = vim.split(globals.result_string, "\n", { trimempty = true })
+    end
+    lines = trim_table(lines)
+    vim.api.nvim_buf_set_text(
+        globals.curr_buffer,
+        globals.start_pos[2] - 1,
+        globals.start_pos[3] - 1,
+        globals.end_pos[2] - 1,
+        globals.end_pos[3] > globals.start_pos[3] and globals.end_pos[3] or globals.end_pos[3] - 1,
+        lines
+    )
+    -- in case another replacement happens
+    globals.end_pos[2] = globals.start_pos[2] + #lines - 1
+    globals.end_pos[3] = string.len(lines[#lines])
+    if not opts.no_auto_close then
+        if globals.float_win ~= nil then
+            vim.api.nvim_win_hide(globals.float_win)
+        end
+        if globals.result_buffer ~= nil then
+            vim.api.nvim_buf_delete(globals.result_buffer, { force = true })
+        end
+        reset()
+    end
+end
+
+return close_window

--- a/lua/gen/window/create.lua
+++ b/lua/gen/window/create.lua
@@ -1,11 +1,16 @@
+-- lua/gen/window/create.lua
 local globals = require("gen.utils.globals")
+local default_opts = require("gen.utils.default_options")
+local get_window = require("gen.window.get")
 local close_window = require("gen.window.close")
-local get_window_options = require("gen.window.get")
-local default_options = require("gen.utils.default_options")
+local reset = require("gen.utils.reset")
+
+local writer = require("gen.core.writer") -- para escribir si hace falta
 
 local M = {}
 
-for k, v in pairs(default_options) do
+-- Copia de default_options
+for k, v in pairs(default_opts) do
     M[k] = v
 end
 
@@ -15,42 +20,51 @@ M.setup = function(opts)
     end
 end
 
+local function setup_window(opts)
+    globals.result_buffer = vim.fn.bufnr("%")
+    globals.float_win = vim.fn.win_getid()
+    vim.api.nvim_set_option_value("filetype", opts.result_filetype, { buf = globals.result_buffer })
+    vim.api.nvim_set_option_value("buftype", "nofile", { buf = globals.result_buffer })
+    vim.api.nvim_set_option_value("wrap", true, { win = globals.float_win })
+    vim.api.nvim_set_option_value("linebreak", true, { win = globals.float_win })
+end
+
 local function create_window(cmd, opts)
-    local function setup_window()
-        globals.result_buffer = vim.fn.bufnr("%")
-        globals.float_win = vim.fn.win_getid()
-        vim.api.nvim_set_option_value("filetype", opts.result_filetype, { buf = globals.result_buffer })
-        vim.api.nvim_set_option_value("buftype", "nofile", { buf = globals.result_buffer })
-        vim.api.nvim_set_option_value("wrap", true, { win = globals.float_win })
-        vim.api.nvim_set_option_value("linebreak", true, { win = globals.float_win })
+    local display_mode = opts.display_mode or M.display_mode
+
+    -- Si ya existía un buffer de resultados, lo eliminamos para evitar “colisiones”
+    if globals.result_buffer then
+        vim.api.nvim_buf_delete(globals.result_buffer, { force = true })
     end
 
-    local display_mode = opts.display_mode or M.display_mode
     if display_mode == "float" then
-        if globals.result_buffer then
-            vim.api.nvim_buf_delete(globals.result_buffer, { force = true })
-        end
-        local win_opts = vim.tbl_deep_extend("force", get_window_options(opts), opts.win_config)
+        local win_opts = vim.tbl_deep_extend("force", get_window(opts), opts.win_config)
         globals.result_buffer = vim.api.nvim_create_buf(false, true)
         globals.float_win = vim.api.nvim_open_win(globals.result_buffer, true, win_opts)
-        setup_window()
+        setup_window(opts)
     elseif display_mode == "horizontal-split" then
         vim.cmd("split gen.nvim")
-        setup_window()
+        setup_window(opts)
     else
+        -- vertical split
         vim.cmd("vnew gen.nvim")
-        setup_window()
+        setup_window(opts)
     end
+
+    -- Keymaps
     vim.keymap.set("n", "<esc>", function()
         if globals.job_id then
             vim.fn.jobstop(globals.job_id)
         end
     end, { buffer = globals.result_buffer })
+
     vim.keymap.set("n", M.quit_map, "<cmd>quit<cr>", { buffer = globals.result_buffer })
+
     vim.keymap.set("n", M.accept_map, function()
         opts.replace = true
         close_window(opts)
     end, { buffer = globals.result_buffer })
+
     vim.keymap.set("n", M.retry_map, function()
         local buf = 0 -- Current buffer
         if globals.job_id then
@@ -60,8 +74,7 @@ local function create_window(cmd, opts)
         vim.api.nvim_buf_set_option(buf, "modifiable", true)
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, {})
         vim.api.nvim_buf_set_option(buf, "modifiable", false)
-        -- vim.api.nvim_win_close(0, true)
-        M.run_command(cmd, opts)
+        M.run_command(cmd, opts) -- Ojo: si deseas re-ejecutar, tendrías que exponer `run_command` desde init
     end, { buffer = globals.result_buffer })
 end
 

--- a/lua/gen/window/create.lua
+++ b/lua/gen/window/create.lua
@@ -1,8 +1,19 @@
 local globals = {}
 local close_window = require("gen.window.close")
 local get_window_options = require("gen.window.get")
+local default_options = require("gen.utils.default_options")
 
 local M = {}
+
+for k, v in pairs(default_options) do
+    M[k] = v
+end
+
+M.setup = function(opts)
+    for k, v in pairs(opts) do
+        M[k] = v
+    end
+end
 
 local function create_window(cmd, opts)
     local function setup_window()

--- a/lua/gen/window/create.lua
+++ b/lua/gen/window/create.lua
@@ -1,4 +1,4 @@
-local globals = {}
+local globals = require("gen.utils.globals")
 local close_window = require("gen.window.close")
 local get_window_options = require("gen.window.get")
 local default_options = require("gen.utils.default_options")

--- a/lua/gen/window/create.lua
+++ b/lua/gen/window/create.lua
@@ -1,0 +1,57 @@
+local globals = {}
+local close_window = require("gen.window.close")
+local get_window_options = require("gen.window.get")
+
+local M = {}
+
+local function create_window(cmd, opts)
+    local function setup_window()
+        globals.result_buffer = vim.fn.bufnr("%")
+        globals.float_win = vim.fn.win_getid()
+        vim.api.nvim_set_option_value("filetype", opts.result_filetype, { buf = globals.result_buffer })
+        vim.api.nvim_set_option_value("buftype", "nofile", { buf = globals.result_buffer })
+        vim.api.nvim_set_option_value("wrap", true, { win = globals.float_win })
+        vim.api.nvim_set_option_value("linebreak", true, { win = globals.float_win })
+    end
+
+    local display_mode = opts.display_mode or M.display_mode
+    if display_mode == "float" then
+        if globals.result_buffer then
+            vim.api.nvim_buf_delete(globals.result_buffer, { force = true })
+        end
+        local win_opts = vim.tbl_deep_extend("force", get_window_options(opts), opts.win_config)
+        globals.result_buffer = vim.api.nvim_create_buf(false, true)
+        globals.float_win = vim.api.nvim_open_win(globals.result_buffer, true, win_opts)
+        setup_window()
+    elseif display_mode == "horizontal-split" then
+        vim.cmd("split gen.nvim")
+        setup_window()
+    else
+        vim.cmd("vnew gen.nvim")
+        setup_window()
+    end
+    vim.keymap.set("n", "<esc>", function()
+        if globals.job_id then
+            vim.fn.jobstop(globals.job_id)
+        end
+    end, { buffer = globals.result_buffer })
+    vim.keymap.set("n", M.quit_map, "<cmd>quit<cr>", { buffer = globals.result_buffer })
+    vim.keymap.set("n", M.accept_map, function()
+        opts.replace = true
+        close_window(opts)
+    end, { buffer = globals.result_buffer })
+    vim.keymap.set("n", M.retry_map, function()
+        local buf = 0 -- Current buffer
+        if globals.job_id then
+            vim.fn.jobstop(globals.job_id)
+            globals.job_id = nil
+        end
+        vim.api.nvim_buf_set_option(buf, "modifiable", true)
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, {})
+        vim.api.nvim_buf_set_option(buf, "modifiable", false)
+        -- vim.api.nvim_win_close(0, true)
+        M.run_command(cmd, opts)
+    end, { buffer = globals.result_buffer })
+end
+
+return create_window

--- a/lua/gen/window/get.lua
+++ b/lua/gen/window/get.lua
@@ -1,0 +1,34 @@
+local function get_window_options(opts)
+    local cursor = vim.api.nvim_win_get_cursor(0)
+    local new_win_width = vim.api.nvim_win_get_width(0)
+    local win_height = vim.api.nvim_win_get_height(0)
+
+    local middle_row = win_height / 2
+
+    local new_win_height = math.floor(win_height / 2)
+    local new_win_row
+    if cursor[1] <= middle_row then
+        new_win_row = 5
+    else
+        new_win_row = -5 - new_win_height
+    end
+
+    local result = {
+        relative = "cursor",
+        width = new_win_width,
+        height = new_win_height,
+        row = new_win_row,
+        col = 0,
+        style = "minimal",
+        border = "rounded",
+    }
+
+    local version = vim.version()
+    if version.major > 0 or version.minor >= 10 then
+        result.hide = opts.hidden
+    end
+
+    return result
+end
+
+return get_window_options


### PR DESCRIPTION
## What does this PR do?

This pull request introduces support for multi-language chat prompts. Now, the prompts can be defined with translations for multiple languages, and the plugin will automatically use the prompt corresponding to the language set in the configuration (`M.language`).

### How does it work?

1. Prompts can now be defined as tables with multiple translations. For example:
   ```lua
   return {
       Generate = {
           prompt = {
               en = "Generate: $input",
               es = "Generar: $input",
           },
           replace = true,
       },
   }
   ```

2. A `language` option has been added to the configuration:
   ```lua
   require("gen").setup({
       language = "es", -- Set to the desired language, e.g., "en", "es"
   })
   ```
