### PR TITLE
Support extract option as a function

### DIFF
--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -83,7 +83,10 @@ local function close_window(opts)
         local extracted
 
         if type(opts.extract) == "function" then
-            extracted = opts.extract({ result_string = globals.result_string })
+            extracted = opts.extract({
+                result_string = globals.result_string,
+                model = opts.model,
+            })
         else
             extracted = globals.result_string:match(opts.extract)
         end

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -80,7 +80,14 @@ M.setup = function(opts) for k, v in pairs(opts) do M[k] = v end end
 local function close_window(opts)
     local lines = {}
     if opts.extract then
-        local extracted = globals.result_string:match(opts.extract)
+        local extracted
+
+        if type(opts.extract) == "function" then
+            extracted = opts.extract({ result_string = globals.result_string })
+        else
+            extracted = globals.result_string:match(opts.extract)
+        end
+
         if not extracted then
             if not opts.no_auto_close then
                 vim.api.nvim_win_hide(globals.float_win)
@@ -320,7 +327,11 @@ M.exec = function(options)
     end
 
     prompt = substitute_placeholders(prompt)
-    opts.extract = substitute_placeholders(opts.extract)
+
+    if type(opts.extract) == "string" then
+        opts.extract = substitute_placeholders(opts.extract)
+    end
+
     prompt = string.gsub(prompt, "%%", "%%%%")
 
     globals.result_string = ""


### PR DESCRIPTION
Add extract parameter to be specified as a function instead of just a string, to allow custom behavior to be implemented.

Rationale: the new deepseek-r1 show promising results with ollama, but it includes it's thinking context in the format `<think>context</think>answer`, and I'm only interested in extracting the `answer` bit into my working text buffer, and I wanted a generic `extract`, and I wanted it to work whether the `<think>` tags are available or not, and that wouldn't be possible with the standard string extract function. Therefore, I added support for a function.

With this, I add the following to my global opts:

```
         extract = function (opts)
            local result = opts.result_string:match("^<think>.-</think>(.*)$")

            if result then
               return result
            else
               return opts.result_string
            end
         end,
```

Then it would work with the built-in prompts, while a the same time allowing the more specific prompts to overwrite the extract parameter.