### PR TITLE
fix: typo in a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Example with Lazy
 },
 ```
 
-Here are all [available models](https://ollama.ai/library).
+Here are all [available models](https://ollama.com/library).
 
 Alternatively, you can call the `setup` function:
 


### PR DESCRIPTION
I changed the domain of Ollama's link from ".ai" to ".com" because it wasn't loading.