### PR TITLE
feat: virtual text preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ You can use the following properties per prompt:
    - `$input`: Additional user input
    - `$register`: Value of the unnamed register (yanked text)
 - `replace`: `true` if the selected text shall be replaced with the generated output
-- `preview`: `true` to display virtual text for the generated result. Can't be used `replace` or `hidden` set to `true`
+- `preview`: `true` to display virtual text for the generated result. Can't be used `replace`
 - `extract`: Regular expression used to extract the generated result
 - `model`: The model to use, default: `mistral`
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ You can use the following properties per prompt:
    - `$input`: Additional user input
    - `$register`: Value of the unnamed register (yanked text)
 - `replace`: `true` if the selected text shall be replaced with the generated output
+- `preview`: `true` to display virtual text for the generated result. Can't be used `replace` or `hidden` set to `true`
 - `extract`: Regular expression used to extract the generated result
 - `model`: The model to use, default: `mistral`
 

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -1,6 +1,6 @@
 local prompts = require("gen.prompts")
 local M = {}
-
+vim.api.nvim_set_hl(0, 'GenPreviewText', { fg = '#808080' })
 local globals = {}
 local function reset(keep_selection)
     if not keep_selection then
@@ -77,6 +77,11 @@ for k, v in pairs(default_options) do M[k] = v end
 
 M.setup = function(opts) for k, v in pairs(opts) do M[k] = v end end
 
+local function clear_preview_lines()
+    local gen_preview_ns = vim.api.nvim_create_namespace('gen')
+    vim.api.nvim_buf_del_extmark(globals.curr_buffer, gen_preview_ns, 1)
+end
+
 local function close_window(opts)
     local lines = {}
     if opts.extract then
@@ -97,24 +102,40 @@ local function close_window(opts)
         lines = vim.split(globals.result_string, "\n", {trimempty = true})
     end
     lines = trim_table(lines)
-    vim.api.nvim_buf_set_text(globals.curr_buffer, globals.start_pos[2] - 1,
-                              globals.start_pos[3] - 1, globals.end_pos[2] - 1,
-                              globals.end_pos[3] > globals.start_pos[3] and
-                                  globals.end_pos[3] or globals.end_pos[3] - 1,
-                              lines)
-    -- in case another replacement happens
-    globals.end_pos[2] = globals.start_pos[2] + #lines - 1
-    globals.end_pos[3] = string.len(lines[#lines])
-    if not opts.no_auto_close then
-        if globals.float_win ~= nil then
-            vim.api.nvim_win_hide(globals.float_win)
+    clear_preview_lines()
+    if opts.replace then
+        vim.api.nvim_buf_set_text(globals.curr_buffer, globals.start_pos[2] - 1,
+                globals.start_pos[3] - 1, globals.end_pos[2] - 1,
+                globals.end_pos[3] > globals.start_pos[3] and
+                globals.end_pos[3] or globals.end_pos[3] - 1,
+                lines)
+        -- in case another replacement happens
+        globals.end_pos[2] = globals.start_pos[2] + #lines - 1
+        globals.end_pos[3] = string.len(lines[#lines])
+        if not opts.no_auto_close then
+            if globals.float_win ~= nil then
+                vim.api.nvim_win_hide(globals.float_win)
+            end
+            if globals.result_buffer ~= nil then
+                vim.api.nvim_buf_delete(globals.result_buffer, {force = true})
+            end
+            reset()
         end
-        if globals.result_buffer ~= nil then
-            vim.api.nvim_buf_delete(globals.result_buffer, {force = true})
+    elseif opts.preview then
+        local preview_lines = {}
+        for _, line in ipairs(lines) do
+            table.insert(preview_lines, {{line, "GenPreviewText"}})
         end
-        reset()
+        local gen_preview_ns = vim.api.nvim_create_namespace('gen')
+        vim.api.nvim_buf_set_extmark(globals.curr_buffer, gen_preview_ns, globals.end_pos[2] - 1, 0, {
+            id = 1,
+            virt_lines = preview_lines,
+            virt_lines_above = false
+        })
     end
+
 end
+
 
 local function get_window_options(opts)
     local cursor = vim.api.nvim_win_get_cursor(0)
@@ -456,7 +477,7 @@ M.run_command = function(cmd, opts)
             end
         end,
         on_exit = function(_, b)
-            if b == 0 and opts.replace and globals.result_buffer then
+            if b == 0 and globals.result_buffer and (opts.replace or opts.preview) then
                 close_window(opts)
             end
         end
@@ -471,6 +492,7 @@ M.run_command = function(cmd, opts)
             if globals.result_buffer then
                 vim.api.nvim_buf_delete(globals.result_buffer, {force = true})
             end
+            clear_preview_lines()
             reset(true) -- keep selection in case of subsequent retries
         end
     })

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -259,9 +259,11 @@ end
 M.exec = function(options)
     local opts = vim.tbl_deep_extend("force", M, options)
     if opts.hidden then
-        -- the only reasonable thing to do if no output can be seen
         opts.display_mode = 'float' -- uses the `hide` option
-        opts.replace = true
+        if not opts.preview then
+            -- the only reasonable thing to do if no output can be seen
+            opts.replace = true
+        end
     end
 
     if type(opts.init) == 'function' then opts.init(opts) end

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -1,6 +1,7 @@
 local prompts = require("gen.prompts")
 local M = {}
 vim.api.nvim_set_hl(0, 'GenPreviewText', { fg = '#808080' })
+vim.api.nvim_set_hl(0, 'GenPreviewDelete', { fg = '#ff8080' })
 local globals = {}
 local function reset(keep_selection)
     if not keep_selection then
@@ -80,6 +81,7 @@ M.setup = function(opts) for k, v in pairs(opts) do M[k] = v end end
 local function clear_preview_lines()
     local gen_preview_ns = vim.api.nvim_create_namespace('gen')
     vim.api.nvim_buf_del_extmark(globals.curr_buffer, gen_preview_ns, 1)
+    vim.api.nvim_buf_del_extmark(globals.curr_buffer, gen_preview_ns, 2)
 end
 
 local function close_window(opts)
@@ -127,8 +129,14 @@ local function close_window(opts)
             table.insert(preview_lines, {{line, "GenPreviewText"}})
         end
         local gen_preview_ns = vim.api.nvim_create_namespace('gen')
-        vim.api.nvim_buf_set_extmark(globals.curr_buffer, gen_preview_ns, globals.end_pos[2] - 1, 0, {
+        vim.api.nvim_buf_set_extmark(globals.curr_buffer, gen_preview_ns, globals.start_pos[2] - 1, 1, {
             id = 1,
+            sign_text = '-',
+            sign_hl_group = 'GenPreviewDelete',
+            end_line = globals.end_pos[2] - 1
+        })
+        vim.api.nvim_buf_set_extmark(globals.curr_buffer, gen_preview_ns, globals.end_pos[2] - 1, 0, {
+            id = 2,
             virt_lines = preview_lines,
             virt_lines_above = false
         })


### PR DESCRIPTION
This adds an option for custom prompts to display virtual text before accepting the generated result.

I've looked through the issues and noticed that a "diff view" is a common request. I believe this achieves the same result, but is easier to implement. Also, this allows to handle the `hidden` option in a more sane way, allowing to review the changes before accepting even without a result_buffer.

I've tested this with the following config:
```
require('gen').setup({
        model = "llama3.2:latest",
        accept_map = "<leader><cr>",
        display_mode = "split", -- also checked float
        no_auto_close = true, -- also checked false
        hidden = false, -- also checked true
        })
require('gen').prompts['Fix_Code'] = {
    prompt = "Fix the following code. Only output the result in format ```$filetype\n...\n```:\n```$filetype\n$text\n```",
    preview = true,
    extract = "```$filetype\n(.-)```"
}
```