### PR TITLE
feat: No split in display mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Example with Lazy
         accept_map = "<c-cr>", -- set keymap to replace the previous selection with the last result
         host = "localhost", -- The host running the Ollama service.
         port = "11434", -- The port on which the Ollama service is listening.
-        display_mode = "float", -- The display mode. Can be "float" or "split" or "horizontal-split".
+        display_mode = "float", -- The display mode. Can be "float" or "split" or "horizontal-split" or "vertical-split" or "no-split".
         show_prompt = false, -- Shows the prompt submitted to Ollama. Can be true (3 lines) or "full".
         show_model = false, -- Displays which model you are using at the beginning of your chat session.
         no_auto_close = false, -- Never closes the window automatically.

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -208,8 +208,11 @@ local function create_window(cmd, opts)
     elseif display_mode == "horizontal-split" then
         vim.cmd("split gen.nvim")
         setup_window()
-    else
+    elseif display_mode == "verticlal-split" then
         vim.cmd("vnew gen.nvim")
+        setup_window()
+    else
+        vim.cmd("new gen.nvim")
         setup_window()
     end
     vim.keymap.set("n", "<esc>", function()

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -212,7 +212,7 @@ local function create_window(cmd, opts)
         vim.cmd("vnew gen.nvim")
         setup_window()
     else
-        vim.cmd("new gen.nvim")
+        vim.cmd("edit gen.nvim")
         setup_window()
     end
     vim.keymap.set("n", "<esc>", function()

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -208,10 +208,14 @@ local function create_window(cmd, opts)
     elseif display_mode == "horizontal-split" then
         vim.cmd("split gen.nvim")
         setup_window()
-    elseif display_mode == "verticlal-split" then
+    elseif display_mode == "vertical-split" then
         vim.cmd("vnew gen.nvim")
         setup_window()
+    elseif display_mode == "no-split" then
+        vim.cmd("edit gen.nvim")
+        setup_window()
     else
+        vim.notify("Gen.nvim warning : Invalid display mode specified.", vim.log.levels.WARN)
         vim.cmd("edit gen.nvim")
         setup_window()
     end


### PR DESCRIPTION
Added `no-split` method for opening chat without any splits. Also added notify warning for invalid `display-mode` values with a fallback method.