### PR TITLE
fix(choices): npe when processing web ui response; plus add opt usage…

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Example with Lazy
         display_mode = "float", -- The display mode. Can be "float" or "split" or "horizontal-split" or "vertical-split".
         show_prompt = false, -- Shows the prompt submitted to Ollama. Can be true (3 lines) or "full".
         show_model = false, -- Displays which model you are using at the beginning of your chat session.
+        show_usage = false, -- Displays input and output tokens spent for a given request.
         no_auto_close = false, -- Never closes the window automatically.
         file = false, -- Write the payload to a temporary file to keep the command short.
         hidden = false, -- Hide the generation window (if true, will implicitly set `prompt.replace = true`), requires Neovim >= 0.10

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -25,7 +25,9 @@ end
 reset()
 
 local function trim_table(tbl)
-    local function is_whitespace(str) return str:match("^%s*$") ~= nil end
+    local function is_whitespace(str)
+        return str:match("^%s*$") ~= nil
+    end
 
     while #tbl > 0 and (tbl[1] == "" or is_whitespace(tbl[1])) do
         table.remove(tbl, 1)
@@ -44,25 +46,31 @@ local default_options = {
     port = "11434",
     file = false,
     debug = false,
-    body = {stream = true},
+    body = { stream = true },
     show_prompt = false,
     show_model = false,
+    show_usage = false,
     quit_map = "q",
     accept_map = "<c-cr>",
     retry_map = "<c-r>",
     hidden = false,
     command = function(options)
-        return "curl -q --silent --no-buffer -X POST http://" .. options.host ..
-                   ":" .. options.port .. "/api/chat -d $body"
+        return "curl -q --silent --no-buffer -X POST http://"
+            .. options.host
+            .. ":"
+            .. options.port
+            .. "/api/chat -d $body"
     end,
     json_response = true,
     display_mode = "float",
     no_auto_close = false,
-    init = function() pcall(io.popen, "ollama serve > /dev/null 2>&1 &") end,
+    init = function()
+        pcall(io.popen, "ollama serve > /dev/null 2>&1 &")
+    end,
     list_models = function(options)
         local response = vim.fn.systemlist(
-                             "curl -q --silent --no-buffer http://" .. options.host ..
-                                 ":" .. options.port .. "/api/tags")
+            "curl -q --silent --no-buffer http://" .. options.host .. ":" .. options.port .. "/api/tags"
+        )
         local list = vim.fn.json_decode(response)
         local models = {}
         for key, _ in pairs(list.models) do
@@ -71,11 +79,17 @@ local default_options = {
         table.sort(models)
         return models
     end,
-    result_filetype = "markdown"
+    result_filetype = "markdown",
 }
-for k, v in pairs(default_options) do M[k] = v end
+for k, v in pairs(default_options) do
+    M[k] = v
+end
 
-M.setup = function(opts) for k, v in pairs(opts) do M[k] = v end end
+M.setup = function(opts)
+    for k, v in pairs(opts) do
+        M[k] = v
+    end
+end
 
 local function close_window(opts)
     local lines = {}
@@ -95,23 +109,25 @@ local function close_window(opts)
             if not opts.no_auto_close then
                 vim.api.nvim_win_hide(globals.float_win)
                 if globals.result_buffer ~= nil then
-                    vim.api.nvim_buf_delete(globals.result_buffer,
-                                            {force = true})
+                    vim.api.nvim_buf_delete(globals.result_buffer, { force = true })
                 end
                 reset()
             end
             return
         end
-        lines = vim.split(extracted, "\n", {trimempty = true})
+        lines = vim.split(extracted, "\n", { trimempty = true })
     else
-        lines = vim.split(globals.result_string, "\n", {trimempty = true})
+        lines = vim.split(globals.result_string, "\n", { trimempty = true })
     end
     lines = trim_table(lines)
-    vim.api.nvim_buf_set_text(globals.curr_buffer, globals.start_pos[2] - 1,
-                              globals.start_pos[3] - 1, globals.end_pos[2] - 1,
-                              globals.end_pos[3] > globals.start_pos[3] and
-                                  globals.end_pos[3] or globals.end_pos[3] - 1,
-                              lines)
+    vim.api.nvim_buf_set_text(
+        globals.curr_buffer,
+        globals.start_pos[2] - 1,
+        globals.start_pos[3] - 1,
+        globals.end_pos[2] - 1,
+        globals.end_pos[3] > globals.start_pos[3] and globals.end_pos[3] or globals.end_pos[3] - 1,
+        lines
+    )
     -- in case another replacement happens
     globals.end_pos[2] = globals.start_pos[2] + #lines - 1
     globals.end_pos[3] = string.len(lines[#lines])
@@ -120,7 +136,7 @@ local function close_window(opts)
             vim.api.nvim_win_hide(globals.float_win)
         end
         if globals.result_buffer ~= nil then
-            vim.api.nvim_buf_delete(globals.result_buffer, {force = true})
+            vim.api.nvim_buf_delete(globals.result_buffer, { force = true })
         end
         reset()
     end
@@ -148,7 +164,7 @@ local function get_window_options(opts)
         row = new_win_row,
         col = 0,
         style = "minimal",
-        border = "rounded"
+        border = "rounded",
     }
 
     local version = vim.version()
@@ -160,11 +176,11 @@ local function get_window_options(opts)
 end
 
 local function write_to_buffer(lines)
-    if not globals.result_buffer or
-        not vim.api.nvim_buf_is_valid(globals.result_buffer) then return end
+    if not globals.result_buffer or not vim.api.nvim_buf_is_valid(globals.result_buffer) then
+        return
+    end
 
-    local all_lines = vim.api.nvim_buf_get_lines(globals.result_buffer, 0, -1,
-                                                 false)
+    local all_lines = vim.api.nvim_buf_get_lines(globals.result_buffer, 0, -1, false)
 
     local last_row = #all_lines
     local last_row_content = all_lines[last_row]
@@ -172,10 +188,15 @@ local function write_to_buffer(lines)
 
     local text = table.concat(lines or {}, "\n")
 
-    vim.api.nvim_set_option_value("modifiable", true,
-                                  {buf = globals.result_buffer})
-    vim.api.nvim_buf_set_text(globals.result_buffer, last_row - 1, last_col,
-                              last_row - 1, last_col, vim.split(text, "\n"))
+    vim.api.nvim_set_option_value("modifiable", true, { buf = globals.result_buffer })
+    vim.api.nvim_buf_set_text(
+        globals.result_buffer,
+        last_row - 1,
+        last_col,
+        last_row - 1,
+        last_col,
+        vim.split(text, "\n")
+    )
 
     if globals.float_win ~= nil and vim.api.nvim_win_is_valid(globals.float_win) then
         local cursor_pos = vim.api.nvim_win_get_cursor(globals.float_win)
@@ -183,37 +204,31 @@ local function write_to_buffer(lines)
         -- Move the cursor to the end of the new lines
         if cursor_pos[1] == last_row then
             local new_last_row = last_row + #lines - 1
-            vim.api.nvim_win_set_cursor(globals.float_win, {new_last_row, 0})
+            vim.api.nvim_win_set_cursor(globals.float_win, { new_last_row, 0 })
         end
     end
 
-    vim.api.nvim_set_option_value("modifiable", false,
-                                  {buf = globals.result_buffer})
+    vim.api.nvim_set_option_value("modifiable", false, { buf = globals.result_buffer })
 end
 
 local function create_window(cmd, opts)
     local function setup_window()
         globals.result_buffer = vim.fn.bufnr("%")
         globals.float_win = vim.fn.win_getid()
-        vim.api.nvim_set_option_value("filetype", opts.result_filetype,
-                                      {buf = globals.result_buffer})
-        vim.api.nvim_set_option_value("buftype", "nofile",
-                                      {buf = globals.result_buffer})
-        vim.api.nvim_set_option_value("wrap", true, {win = globals.float_win})
-        vim.api.nvim_set_option_value("linebreak", true,
-                                      {win = globals.float_win})
+        vim.api.nvim_set_option_value("filetype", opts.result_filetype, { buf = globals.result_buffer })
+        vim.api.nvim_set_option_value("buftype", "nofile", { buf = globals.result_buffer })
+        vim.api.nvim_set_option_value("wrap", true, { win = globals.float_win })
+        vim.api.nvim_set_option_value("linebreak", true, { win = globals.float_win })
     end
 
     local display_mode = opts.display_mode or M.display_mode
     if display_mode == "float" then
         if globals.result_buffer then
-            vim.api.nvim_buf_delete(globals.result_buffer, {force = true})
+            vim.api.nvim_buf_delete(globals.result_buffer, { force = true })
         end
-        local win_opts = vim.tbl_deep_extend("force", get_window_options(opts),
-                                             opts.win_config)
+        local win_opts = vim.tbl_deep_extend("force", get_window_options(opts), opts.win_config)
         globals.result_buffer = vim.api.nvim_create_buf(false, true)
-        globals.float_win = vim.api.nvim_open_win(globals.result_buffer, true,
-                                                  win_opts)
+        globals.float_win = vim.api.nvim_open_win(globals.result_buffer, true, win_opts)
         setup_window()
     elseif display_mode == "horizontal-split" then
         vim.cmd("split gen.nvim")
@@ -230,14 +245,15 @@ local function create_window(cmd, opts)
         setup_window()
     end
     vim.keymap.set("n", "<esc>", function()
-        if globals.job_id then vim.fn.jobstop(globals.job_id) end
-    end, {buffer = globals.result_buffer})
-    vim.keymap.set("n", M.quit_map, "<cmd>quit<cr>",
-                   {buffer = globals.result_buffer})
+        if globals.job_id then
+            vim.fn.jobstop(globals.job_id)
+        end
+    end, { buffer = globals.result_buffer })
+    vim.keymap.set("n", M.quit_map, "<cmd>quit<cr>", { buffer = globals.result_buffer })
     vim.keymap.set("n", M.accept_map, function()
         opts.replace = true
         close_window(opts)
-    end, {buffer = globals.result_buffer})
+    end, { buffer = globals.result_buffer })
     vim.keymap.set("n", M.retry_map, function()
         local buf = 0 -- Current buffer
         if globals.job_id then
@@ -249,18 +265,20 @@ local function create_window(cmd, opts)
         vim.api.nvim_buf_set_option(buf, "modifiable", false)
         -- vim.api.nvim_win_close(0, true)
         M.run_command(cmd, opts)
-    end, {buffer = globals.result_buffer})
+    end, { buffer = globals.result_buffer })
 end
 
 M.exec = function(options)
     local opts = vim.tbl_deep_extend("force", M, options)
     if opts.hidden then
         -- the only reasonable thing to do if no output can be seen
-        opts.display_mode = 'float' -- uses the `hide` option
+        opts.display_mode = "float" -- uses the `hide` option
         opts.replace = true
     end
 
-    if type(opts.init) == 'function' then opts.init(opts) end
+    if type(opts.init) == "function" then
+        opts.init(opts)
+    end
 
     if globals.result_buffer ~= vim.fn.winbufnr(0) then
         globals.curr_buffer = vim.fn.winbufnr(0)
@@ -282,32 +300,34 @@ M.exec = function(options)
     local content
     if globals.start_pos == globals.end_pos then
         -- get text from whole buffer
-        content = table.concat(vim.api.nvim_buf_get_lines(globals.curr_buffer,
-                                                          0, -1, false), "\n")
+        content = table.concat(vim.api.nvim_buf_get_lines(globals.curr_buffer, 0, -1, false), "\n")
     else
-        content = table.concat(vim.api.nvim_buf_get_text(globals.curr_buffer,
-                                                         globals.start_pos[2] -
-                                                             1,
-                                                         globals.start_pos[3] -
-                                                             1,
-                                                         globals.end_pos[2] - 1,
-                                                         globals.end_pos[3], {}),
-                               "\n")
-
+        content = table.concat(
+            vim.api.nvim_buf_get_text(
+                globals.curr_buffer,
+                globals.start_pos[2] - 1,
+                globals.start_pos[3] - 1,
+                globals.end_pos[2] - 1,
+                globals.end_pos[3],
+                {}
+            ),
+            "\n"
+        )
     end
     local function substitute_placeholders(input)
-        if not input then return input end
+        if not input then
+            return input
+        end
         local text = input
         if string.find(text, "%$input") then
             local answer = vim.fn.input("Prompt: ")
             text = string.gsub(text, "%$input", answer)
         end
 
-        text = string.gsub(text, "%$register_([%w*+:/\"])", function(r_name)
+        text = string.gsub(text, '%$register_([%w*+:/"])', function(r_name)
             local register = vim.fn.getreg(r_name)
             if not register or register:match("^%s*$") then
-                error("Prompt uses $register_" .. rname .. " but register " ..
-                          rname .. " is empty")
+                error("Prompt uses $register_" .. rname .. " but register " .. rname .. " is empty")
             end
             return register
         end)
@@ -330,8 +350,8 @@ M.exec = function(options)
     local prompt = opts.prompt
 
     if type(prompt) == "function" then
-        prompt = prompt({content = content, filetype = vim.bo.filetype})
-        if type(prompt) ~= 'string' or string.len(prompt) == 0 then
+        prompt = prompt({ content = content, filetype = vim.bo.filetype })
+        if type(prompt) ~= "string" or string.len(prompt) == 0 then
             return
         end
     end
@@ -352,8 +372,8 @@ M.exec = function(options)
         local json = vim.fn.json_encode(body)
         if shellescape then
             json = vim.fn.shellescape(json)
-            if vim.o.shell == 'cmd.exe' then
-                json = string.gsub(json, '\\\"\"', '\\\\\\\"')
+            if vim.o.shell == "cmd.exe" then
+                json = string.gsub(json, '\\""', '\\\\\\"')
             end
         end
         return json
@@ -361,7 +381,7 @@ M.exec = function(options)
 
     opts.prompt = prompt
 
-    if type(opts.command) == 'function' then
+    if type(opts.command) == "function" then
         cmd = opts.command(opts)
     else
         cmd = M.command
@@ -373,13 +393,13 @@ M.exec = function(options)
     end
     cmd = string.gsub(cmd, "%$model", opts.model)
     if string.find(cmd, "%$body") then
-        local body = vim.tbl_extend("force",
-                                    {model = opts.model, stream = true},
-                                    opts.body)
+        local body = vim.tbl_extend("force", { model = opts.model, stream = true }, opts.body)
         local messages = {}
-        if globals.context then messages = globals.context end
+        if globals.context then
+            messages = globals.context
+        end
         -- Add new prompt to the context
-        table.insert(messages, {role = "user", content = prompt})
+        table.insert(messages, { role = "user", content = prompt })
         body.messages = messages
         if M.model_options ~= nil then -- llamacpp server - model options: eg. temperature, top_k, top_p
             body = vim.tbl_extend("force", body, M.model_options)
@@ -401,41 +421,43 @@ M.exec = function(options)
         end
     end
 
-    if globals.context ~= nil then write_to_buffer({"", "", "---", ""}) end
+    if globals.context ~= nil then
+        write_to_buffer({ "", "", "---", "" })
+    end
 
     M.run_command(cmd, opts)
-
 end
 
 M.run_command = function(cmd, opts)
     -- vim.print('run_command', cmd, opts)
-    if globals.result_buffer == nil or globals.float_win == nil or
-        not vim.api.nvim_win_is_valid(globals.float_win) then
+    if globals.result_buffer == nil or globals.float_win == nil or not vim.api.nvim_win_is_valid(globals.float_win) then
         create_window(cmd, opts)
         if opts.show_model then
-            write_to_buffer({"# Chat with " .. opts.model, ""})
+            write_to_buffer({ "# Chat with " .. opts.model, "" })
         end
     end
     local partial_data = ""
-    if opts.debug then print(cmd) end
+    if opts.debug then
+        print(cmd)
+    end
 
     globals.job_id = vim.fn.jobstart(cmd, {
         -- stderr_buffered = opts.debug,
         on_stdout = function(_, data, _)
             -- window was closed, so cancel the job
-            if not globals.float_win or
-                not vim.api.nvim_win_is_valid(globals.float_win) then
+            if not globals.float_win or not vim.api.nvim_win_is_valid(globals.float_win) then
                 if globals.job_id then
                     vim.fn.jobstop(globals.job_id)
                 end
                 if globals.result_buffer then
-                    vim.api.nvim_buf_delete(globals.result_buffer,
-                                            {force = true})
+                    vim.api.nvim_buf_delete(globals.result_buffer, { force = true })
                 end
                 reset()
                 return
             end
-            if opts.debug then vim.print('Response data: ', data) end
+            if opts.debug then
+                vim.print("Response data: ", data)
+            end
             for _, line in ipairs(data) do
                 partial_data = partial_data .. line
                 if line:sub(-1) == "}" then
@@ -443,35 +465,34 @@ M.run_command = function(cmd, opts)
                 end
             end
 
-            local lines = vim.split(partial_data, "\n", {trimempty = true})
+            local lines = vim.split(partial_data, "\n", { trimempty = true })
 
             partial_data = table.remove(lines) or ""
 
             for _, line in ipairs(lines) do
-                Process_response(line, globals.job_id, opts.json_response)
+                Process_response(line, opts.json_response, opts.show_usage)
             end
 
             if partial_data:sub(-1) == "}" then
-                Process_response(partial_data, globals.job_id,
-                                 opts.json_response)
+                Process_response(partial_data, opts.json_response, opts.show_usage)
                 partial_data = ""
             end
         end,
         on_stderr = function(_, data, _)
             if opts.debug then
                 -- window was closed, so cancel the job
-                if not globals.float_win or
-                    not vim.api.nvim_win_is_valid(globals.float_win) then
+                if not globals.float_win or not vim.api.nvim_win_is_valid(globals.float_win) then
                     if globals.job_id then
                         vim.fn.jobstop(globals.job_id)
                     end
                     return
                 end
 
-                if data == nil or #data == 0 then return end
+                if data == nil or #data == 0 then
+                    return
+                end
 
-                globals.result_string = globals.result_string ..
-                                            table.concat(data, "\n")
+                globals.result_string = globals.result_string .. table.concat(data, "\n")
                 local lines = vim.split(globals.result_string, "\n")
                 write_to_buffer(lines)
             end
@@ -480,20 +501,22 @@ M.run_command = function(cmd, opts)
             if b == 0 and opts.replace and globals.result_buffer then
                 close_window(opts)
             end
-        end
+        end,
     })
 
-    local group = vim.api.nvim_create_augroup("gen", {clear = true})
-    vim.api.nvim_create_autocmd('WinClosed', {
+    local group = vim.api.nvim_create_augroup("gen", { clear = true })
+    vim.api.nvim_create_autocmd("WinClosed", {
         buffer = globals.result_buffer,
         group = group,
         callback = function()
-            if globals.job_id then vim.fn.jobstop(globals.job_id) end
+            if globals.job_id then
+                vim.fn.jobstop(globals.job_id)
+            end
             if globals.result_buffer then
-                vim.api.nvim_buf_delete(globals.result_buffer, {force = true})
+                vim.api.nvim_buf_delete(globals.result_buffer, { force = true })
             end
             reset(true) -- keep selection in case of subsequent retries
-        end
+        end,
     })
 
     if opts.show_prompt then
@@ -510,15 +533,23 @@ M.run_command = function(cmd, opts)
             end
         end
         local heading = "#"
-        if M.show_model then heading = "##" end
+        if M.show_model then
+            heading = "##"
+        end
         write_to_buffer({
-            heading .. " Prompt:", "", table.concat(short_prompt, "\n"), "",
-            "---", ""
+            heading .. " Prompt:",
+            "",
+            table.concat(short_prompt, "\n"),
+            "",
+            "---",
+            "",
         })
     end
 
     vim.api.nvim_buf_attach(globals.result_buffer, false, {
-        on_detach = function() globals.result_buffer = nil end
+        on_detach = function()
+            globals.result_buffer = nil
+        end,
     })
 end
 
@@ -527,14 +558,18 @@ M.win_config = {}
 M.prompts = prompts
 local function select_prompt(cb)
     local promptKeys = {}
-    for key, _ in pairs(M.prompts) do table.insert(promptKeys, key) end
+    for key, _ in pairs(M.prompts) do
+        table.insert(promptKeys, key)
+    end
     table.sort(promptKeys)
     vim.ui.select(promptKeys, {
         prompt = "Prompt:",
         format_item = function(item)
             return table.concat(vim.split(item, "_"), " ")
-        end
-    }, function(item) cb(item) end)
+        end,
+    }, function(item)
+        cb(item)
+    end)
 end
 
 vim.api.nvim_create_user_command("Gen", function(arg)
@@ -550,12 +585,14 @@ vim.api.nvim_create_user_command("Gen", function(arg)
             print("Invalid prompt '" .. arg.args .. "'")
             return
         end
-        local p = vim.tbl_deep_extend("force", {mode = mode}, prompt)
+        local p = vim.tbl_deep_extend("force", { mode = mode }, prompt)
         return M.exec(p)
     end
     select_prompt(function(item)
-        if not item then return end
-        local p = vim.tbl_deep_extend("force", {mode = mode}, M.prompts[item])
+        if not item then
+            return
+        end
+        local p = vim.tbl_deep_extend("force", { mode = mode }, M.prompts[item])
         M.exec(p)
     end)
 end, {
@@ -570,13 +607,14 @@ end, {
         end
         table.sort(promptKeys)
         return promptKeys
-    end
+    end,
 })
 
-function Process_response(str, json_response)
-    if string.len(str) == 0 then return end
+function Process_response(str, json_response, show_usage)
+    if string.len(str) == 0 then
+        return
+    end
     local text
-
     if json_response then
         -- llamacpp response string -- 'data: {"content": "hello", .... }' -- remove 'data: ' prefix, before json_decode
         if string.sub(str, 1, 6) == "data: " then
@@ -599,12 +637,12 @@ function Process_response(str, json_response)
                 if result.done then
                     table.insert(globals.context, {
                         role = "assistant",
-                        content = globals.context_buffer
+                        content = globals.context_buffer,
                     })
                     -- Clear the buffer as we're done with this sequence of messages
                     globals.context_buffer = ""
                 end
-            elseif result.choices then -- groq chat endpoint
+            elseif result.choices and #result.choices ~= 0 then -- groq chat endpoint
                 local choice = result.choices[1]
                 local content = choice.delta.content
                 text = content
@@ -619,7 +657,7 @@ function Process_response(str, json_response)
                 if choice.finish_reason == "stop" then
                     table.insert(globals.context, {
                         role = "assistant",
-                        content = globals.context_buffer
+                        content = globals.context_buffer,
                     })
                     -- Clear the buffer as we're done with this sequence of messages
                     globals.context_buffer = ""
@@ -635,15 +673,34 @@ function Process_response(str, json_response)
                     globals.context = result.context
                 end
             end
+            if
+                show_usage
+                and result.usage ~= vim.NIL
+                and result.usage.prompt_tokens
+                and result.usage.completion_tokens
+            then
+                local in_tokens = result.usage.prompt_tokens
+                local out_tokens = result.usage.completion_tokens
+                write_to_buffer({
+                    "",
+                    "",
+                    "---",
+                    "### Usage:",
+                    "> " .. in_tokens .. " input tokens",
+                    "> " .. out_tokens .. " output tokens",
+                })
+            end
         else
-            write_to_buffer({"", "====== ERROR ====", str, "-------------", ""})
+            write_to_buffer({ "", "====== ERROR ====", str, "-------------", "" })
             vim.fn.jobstop(globals.job_id)
         end
     else
         text = str
     end
 
-    if text == nil then return end
+    if text == nil then
+        return
+    end
 
     globals.result_string = globals.result_string .. text
     local lines = vim.split(text, "\n")
@@ -652,7 +709,7 @@ end
 
 M.select_model = function()
     local models = M.list_models(M)
-    vim.ui.select(models, {prompt = "Model:"}, function(item)
+    vim.ui.select(models, { prompt = "Model:" }, function(item)
         if item ~= nil then
             print("Model set to " .. item)
             M.model = item

--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -676,6 +676,7 @@ function Process_response(str, json_response, show_usage)
             if
                 show_usage
                 and result.usage ~= vim.NIL
+                and result.usage
                 and result.usage.prompt_tokens
                 and result.usage.completion_tokens
             then


### PR DESCRIPTION
When using OpenWebUI as a proxy, a response contains `choices` object with delta.content, however the last chunk looks like this:
```json
{
  choices = {},
  created = 1749706792,
  id = "chatcmpl-e29c0d3b",
  model = "us.anthropic.claude-sonnet-4-20250514-v1:0",
  object = "chat.completion.chunk",
  system_fingerprint = "fp",
  usage = {
    completion_tokens = 303,
    prompt_tokens = 21,
    total_tokens = 324
  }
}
```

it contains only usage stats and no content, therefore the code is failing with classic `index out of bounds` exception, which yields following error:
```
...s/nouwa/.local/share/nvim/lazy/gen.nvim/lua/gen/init.lua:649: attempt to index local 'choice' (a nil value)
stack traceback:
	...s/nouwa/.local/share/nvim/lazy/gen.nvim/lua/gen/init.lua:649: in function 'Process_response'
	...s/nouwa/.local/share/nvim/lazy/gen.nvim/lua/gen/init.lua:476: in function <...s/nouwa/.local/share/nvim/lazy/gen.nvim/lua/gen/init.lua:445>
```
to make it work I've added explicit check. 


Also, as a bonus, I've added an optional feature to print out input/output token usage, which could be used as a preparation step to produce actual dollar-cost of a given prompt based on open data, e.g.:
```bash
llm_price () {
        curl -X GET "https://openrouter.ai/api/v1/models" -s 2> /dev/null | jq -r '.data[] | "\(.id) | input: \(.pricing.prompt)$ | output:\(.pricing.completion)$"' | fzf --query "$1"
}
```

I didn't find a quick way to make it work magically due to models have various names across various proxies/in-house deployments and it seems including `fzf` into this plugin to perform fuzzy search is too much of dependency. Perhaps I'd come up with some solution later on, or someone else would have idea hwo to properly match currently selected model with that api response to get $ rate to multiply by token usage.

I tested both fix and optional usage print, seems to work just fine.

Let me know wdyt.
