### PR TITLE
feat: Prepend messages from the opts to the body

### DIFF
--- a/lua/gen/init.lua
+++ b/lua/gen/init.lua
@@ -380,7 +380,9 @@ M.exec = function(options)
         if globals.context then messages = globals.context end
         -- Add new prompt to the context
         table.insert(messages, {role = "user", content = prompt})
-        body.messages = messages
+        local messages_to_send = (opts and opts.body and opts.body.messages) or {}
+        vim.list_extend(messages_to_send, messages)
+        body.messages = messages_to_send
         if M.model_options ~= nil then -- llamacpp server - model options: eg. temperature, top_k, top_p
             body = vim.tbl_extend("force", body, M.model_options)
         end


### PR DESCRIPTION
Here I see an opportunity to add `messages` to the request via opts. The case I'm trying to solve is this:

```sh
curl http://localhost:11434/api/chat -d '{
  "model": "cogito",
  "messages": [
    {
      "role": "system",
      "content": "Enable deep thinking subroutine."
    },
    {
      "role": "user",
      "content": "How many letter Rs are in the word Strawberry?"
    }
  ]
}'
```